### PR TITLE
Enhance versus mode with logging and matchmaking

### DIFF
--- a/custom.html
+++ b/custom.html
@@ -92,10 +92,28 @@
             { field: 'folder', label: 'Pasta' },
             { field: 'level', label: 'Nível de reports' }
           ]));
-        }
-        container.appendChild(section);
       }
-      const levelTitle = document.createElement('h1');
+      container.appendChild(section);
+    }
+    const vsLogs = JSON.parse(localStorage.getItem('versusLogs') || '[]');
+    if (vsLogs.length) {
+      const vsSection = document.createElement('div');
+      vsSection.innerHTML = '<h1 class="custom-title">Versus</h1>';
+      const table = document.createElement('table');
+      table.className = 'ranking-table';
+      const head = document.createElement('tr');
+      head.innerHTML = '<th>Frase</th><th>Entrada</th><th>Resultado</th><th>Reconhecimento</th><th>Tempo de jogo</th>';
+      table.appendChild(head);
+      vsLogs.forEach(l => {
+        const row = document.createElement('tr');
+        const phrase = `${l.phrasePT}#${l.phraseEN}`;
+        row.innerHTML = `<td>${phrase}</td><td>${l.input}</td><td>${l.correct ? 'certo' : 'errado'}</td><td>${formatTime(l.recogTime)}</td><td>${formatTime(l.gameTime)}</td>`;
+        table.appendChild(row);
+      });
+      vsSection.appendChild(table);
+      container.appendChild(vsSection);
+    }
+    const levelTitle = document.createElement('h1');
       levelTitle.className = 'custom-title';
       levelTitle.textContent = 'Detalhe dos níveis';
       container.appendChild(levelTitle);

--- a/versus.html
+++ b/versus.html
@@ -17,6 +17,10 @@
   </nav>
   <div id="bot-list"></div>
   <div id="mode-list"></div>
+  <div id="versus-connect" style="display:none;text-align:center;">
+    <img id="versus-connect-img" width="150" height="150" alt="connecting">
+    <div id="versus-connect-text" style="color:#fff;margin-top:10px;"></div>
+  </div>
   <div id="versus-game" style="display:none;">
     <div id="players">
       <div class="player" id="player-user">


### PR DESCRIPTION
## Summary
- Add connection flow with animated gifs before Versus mode 3 begins and allow tapping to start
- Log every Versus phrase with user input, correctness and timing, showing history on Custom page
- Give players 15% bonus in time comparison and support three AI opponents in mode 2

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68922a202e3083258ba47498d9ec5b6b