### PR TITLE
Play success sound in versus mode

### DIFF
--- a/js/versus.js
+++ b/js/versus.js
@@ -93,6 +93,8 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentFrase = { pt: '', en: '' };
   let botPlayers = [];
 
+  const successSound = new Audio('gamesounds/success.mp3');
+
   const fraseEl = document.getElementById('versus-phrase');
   let userImg = null;
   let botImg = null;
@@ -297,9 +299,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (correto) {
       acertos++;
       flashColor('#40e0d0');
+      successSound.currentTime = 0;
+      successSound.play();
     } else {
       flashColor('red');
     }
+    // Versus mode continues regardless of errors; no game over after mistakes
     const gameElapsed = Date.now() - startGameTime;
     versusLogs.push({
       phrasePT: currentFrase.pt,


### PR DESCRIPTION
## Summary
- play success sound when a user speaks the sentence correctly in versus mode
- ensure versus matches continue without a three-error game over

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68923096e2ac8325b68c404c9b018e1a