### PR TITLE
Add Versus theme toggle and new opponents

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,32 @@ body.custom-gradient {
   color: #333;
 }
 
+body.versus-white {
+  background: linear-gradient(to bottom, #ffffff, #d0d0d0);
+  color: #555;
+}
+
+body.versus-white #top-nav {
+  background: linear-gradient(90deg, #e0e0e0, #f5f5f5);
+}
+
+body.versus-white #top-nav a {
+  color: #555;
+}
+
+body.versus-blue {
+  background: linear-gradient(to bottom, #40e0d0, #0066cc);
+  color: #fff;
+}
+
+body.versus-blue #top-nav {
+  background: linear-gradient(90deg, #40e0d0, #0066cc);
+}
+
+body.versus-blue #top-nav a {
+  color: #fff;
+}
+
 body.dark-mode #pt,
 body.dark-mode #texto-exibicao,
 body.dark-mode #resultado,
@@ -584,12 +610,6 @@ body.dark-mode #clock {
   align-items: flex-start;
   gap: 100px;
   margin-bottom: 30px;
-}
-
-.player-name {
-  font-family: 'Open Sans', sans-serif;
-  font-size: 20px;
-  margin-bottom: 10px;
 }
 
 .player-img {

--- a/js/versus.js
+++ b/js/versus.js
@@ -99,6 +99,24 @@ document.addEventListener('DOMContentLoaded', () => {
   let userImg = null;
   let botImg = null;
 
+  function applyTheme() {
+    fraseEl.style.color = document.body.classList.contains('versus-white') ? '#555' : '#fff';
+  }
+
+  function toggleTheme() {
+    document.body.classList.toggle('versus-white');
+    document.body.classList.toggle('versus-blue');
+    applyTheme();
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key.toLowerCase() === 'h') {
+      toggleTheme();
+    }
+  });
+
+  applyTheme();
+
   if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
     reconhecimento = new SpeechRecognition();
@@ -178,7 +196,6 @@ document.addEventListener('DOMContentLoaded', () => {
     userDiv.className = 'player';
     userDiv.id = 'player-user';
     userDiv.innerHTML = `
-      <div class="player-name">the user</div>
       <img src="users/theuser.png" alt="the user" class="player-img" style="width:${imgSize}px;height:${imgSize}px;">
       <div class="stat-bar time" style="width:${barWidth}px"><div class="fill"></div></div>
       <div class="stat-bar acc" style="width:${barWidth}px"><div class="fill"></div></div>
@@ -195,7 +212,6 @@ document.addEventListener('DOMContentLoaded', () => {
         div.className = 'player';
         div.id = `bot-${idx}`;
         div.innerHTML = `
-          <div class="player-name">${entry.b.name}</div>
           <img src="users/${entry.b.file}" alt="${entry.b.name}" class="player-img" style="width:120px;height:120px;">
           <div class="stat-bar time" style="width:120px"><div class="fill"></div></div>
           <div class="stat-bar acc" style="width:120px"><div class="fill"></div></div>
@@ -210,7 +226,6 @@ document.addEventListener('DOMContentLoaded', () => {
       div.className = 'player';
       div.id = 'player-bot';
       div.innerHTML = `
-        <div class="player-name" id="bot-name">${botAtual.name}</div>
         <img id="bot-avatar" class="player-img" src="users/${botAtual.file}" alt="adversario" style="width:150px;height:150px;">
         <div class="stat-bar time"><div class="fill"></div></div>
         <div class="stat-bar acc"><div class="fill"></div></div>
@@ -242,7 +257,7 @@ document.addEventListener('DOMContentLoaded', () => {
     fraseEl.style.transition = 'none';
     fraseEl.style.opacity = 0;
     fraseEl.style.fontSize = '40px';
-    fraseEl.style.color = '#fff';
+    applyTheme();
     fraseEl.textContent = pt;
     esperado = en.toLowerCase();
     if (modoAtual === 5) {
@@ -265,7 +280,7 @@ document.addEventListener('DOMContentLoaded', () => {
     fraseEl.style.transition = 'color 500ms';
     fraseEl.style.color = cor;
     setTimeout(() => {
-      fraseEl.style.color = '#fff';
+      applyTheme();
     }, 500);
   }
 

--- a/users/bots.json
+++ b/users/bots.json
@@ -65,6 +65,39 @@
         "5": {"precisao": 98, "tempo": 99},
         "6": {"precisao": 100, "tempo": 100}
       }
+    },
+    {
+      "name": "Pablo",
+      "file": "pablo.png",
+      "modes": {
+        "2": {"precisao": 48, "tempo": 65},
+        "3": {"precisao": 50, "tempo": 70},
+        "4": {"precisao": 47, "tempo": 75},
+        "5": {"precisao": 76, "tempo": 70},
+        "6": {"precisao": 45, "tempo": 70}
+      }
+    },
+    {
+      "name": "Tim",
+      "file": "tim.png",
+      "modes": {
+        "2": {"precisao": 77, "tempo": 80},
+        "3": {"precisao": 79, "tempo": 78},
+        "4": {"precisao": 75, "tempo": 70},
+        "5": {"precisao": 74, "tempo": 75},
+        "6": {"precisao": 76, "tempo": 81}
+      }
+    },
+    {
+      "name": "Kim",
+      "file": "kim.png",
+      "modes": {
+        "2": {"precisao": 96, "tempo": 96},
+        "3": {"precisao": 95, "tempo": 94},
+        "4": {"precisao": 94, "tempo": 95},
+        "5": {"precisao": 93, "tempo": 97},
+        "6": {"precisao": 95, "tempo": 96}
+      }
     }
   ]
 }

--- a/versus.html
+++ b/versus.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="dark-mode">
+<body class="versus-white">
   <nav id="top-nav">
     <a href="index.html">home</a>
     <a href="#">fun</a>
@@ -20,13 +20,11 @@
   <div id="versus-game" style="display:none;">
     <div id="players">
       <div class="player" id="player-user">
-        <div class="player-name">the user</div>
         <img src="users/theuser.png" alt="the user" class="player-img">
         <div class="stat-bar time"><div class="fill"></div></div>
         <div class="stat-bar acc"><div class="fill"></div></div>
       </div>
       <div class="player" id="player-bot">
-        <div class="player-name" id="bot-name"></div>
         <img id="bot-avatar" class="player-img" alt="adversario">
         <div class="stat-bar time"><div class="fill"></div></div>
         <div class="stat-bar acc"><div class="fill"></div></div>


### PR DESCRIPTION
## Summary
- Add light and turquoise themes to Versus page, toggled by H key
- Remove player name labels from Versus match display
- Introduce Pablo, Tim and Kim as selectable opponents

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68926294b28c83259ecfb270b04696c6