### PR TITLE
Refactor versus layout and stats

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -601,7 +601,13 @@ body.dark-mode #clock {
 #versus-game {
   display: none;
   text-align: center;
-  margin-top: 40px;
+  margin-top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 20px;
 }
 
 #players {
@@ -647,29 +653,39 @@ body.dark-mode #clock {
   min-height: 40px;
 }
 
-#versus-game #barra-progresso {
+.player-name {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 700;
+  font-size: 14px;
+  padding: 2px 6px;
+  margin-top: 2px;
+  border-radius: 4px;
+  color: #fff;
+}
+
+#ranking-bottom {
+  font-family: 'Open Sans', sans-serif;
+  font-size: 8px;
   position: fixed;
   bottom: 0;
   left: 0;
-  width: 100%;
-  height: 10px;
-  margin: 0;
-  background: #333;
+  right: 0;
+  text-align: center;
+  padding: 4px 0;
 }
 
-#versus-game #barra-preenchida {
-  height: 100%;
-  width: 0;
-  background-color: #ff0000;
-  transition: width 0.1s linear, background-color 0.1s linear;
+.dissolve {
+  animation: dissolve 1s forwards;
+}
+
+@keyframes dissolve {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 
 @media (max-width: 600px) {
   #versus-phrase {
     font-size: 24px;
-  }
-  #versus-game #barra-progresso {
-    height: 8px;
   }
 }
 

--- a/custom.html
+++ b/custom.html
@@ -42,6 +42,14 @@
     }
     document.addEventListener('DOMContentLoaded', () => {
       const container = document.getElementById('custom-content');
+      const vsStats = JSON.parse(localStorage.getItem('versusStats') || '{}');
+      const vsSection = document.createElement('div');
+      vsSection.innerHTML = `
+        <h1 class="custom-title">Versus - Estatísticas</h1>
+        <div class="custom-info">Precisão: ${vsStats.accuracy || 0}%</div>
+        <div class="custom-info">Velocidade: ${vsStats.speed || 0}%</div>
+      `;
+      container.appendChild(vsSection);
       const statsData = JSON.parse(localStorage.getItem('modeStats') || '{}');
       for (let i = 1; i <= 6; i++) {
         const stats = statsData[i] || {};

--- a/versus.html
+++ b/versus.html
@@ -18,20 +18,9 @@
   <div id="bot-list"></div>
   <div id="mode-list"></div>
   <div id="versus-game" style="display:none;">
-    <div id="players">
-      <div class="player" id="player-user">
-        <img src="users/theuser.png" alt="the user" class="player-img">
-        <div class="stat-bar time"><div class="fill"></div></div>
-        <div class="stat-bar acc"><div class="fill"></div></div>
-      </div>
-      <div class="player" id="player-bot">
-        <img id="bot-avatar" class="player-img" alt="adversario">
-        <div class="stat-bar time"><div class="fill"></div></div>
-        <div class="stat-bar acc"><div class="fill"></div></div>
-      </div>
-    </div>
+    <div id="players"></div>
     <div id="versus-phrase"></div>
-    <div id="barra-progresso"><div id="barra-preenchida"></div></div>
+    <div id="ranking-bottom"></div>
   </div>
   <script src="js/versus.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Sort versus opponents by strength and color-code player name labels
- Replace progress bar with live ranking list and dissolve effect after timer
- Expose versus accuracy and speed metrics on the custom page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68926a2c431c83259da85360dd1ca5d8