### PR TITLE
Handle phrase synonyms and enhance Versus race

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -657,10 +657,7 @@ body.dark-mode #clock {
   font-family: 'Open Sans', sans-serif;
   font-weight: 700;
   font-size: 14px;
-  padding: 2px 6px;
   margin-top: 2px;
-  border-radius: 4px;
-  color: #fff;
 }
 
 #ranking-bottom {

--- a/data/frases_corretas.json
+++ b/data/frases_corretas.json
@@ -1,7 +1,7 @@
 {
   "she is": ["cheers"],
   "we can": ["weekend"],
-    "dog": ["star"],
+  "dog": ["star"],
   "cat": ["star"],
   "book": ["star"],
   "car": ["star"],
@@ -50,8 +50,6 @@
   "city": ["star"],
   "computer": ["star"],
   "teacher": ["star"],
-  "student": ["star"]
-}
+  "student": ["star"],
   "i scream": ["ice cream"]
-  
 }


### PR DESCRIPTION
## Summary
- Load and apply `frases_corretas.json` across game modes for synonym-aware phrase checking
- Update Versus: add 10-player race for mode 1, show English-to-English in mode 3, capitalize phrases, and remove name box styling

## Testing
- `node --check js/main.js`
- `node --check js/versus.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68927c57af90832589119a79bcbe9262