### PR TITLE
Adopt blue backgrounds for versus and gradient modes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,7 +12,7 @@ body.dark-mode {
 }
 
 body.gradient-mode {
-  background: linear-gradient(to top, var(--grad-color, #40e0d0) 0%, #000 100%);
+  background: linear-gradient(to bottom, #40e0d0, #0066cc);
 }
 
 body.custom-gradient {
@@ -77,6 +77,14 @@ body.dark-mode #top-nav {
 }
 
 body.dark-mode #top-nav a {
+  color: #fff;
+}
+
+body.gradient-mode #top-nav {
+  background: linear-gradient(90deg, #40e0d0, #0066cc);
+}
+
+body.gradient-mode #top-nav a {
   color: #fff;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -294,7 +294,7 @@ let downPlaying = false;
 let downTimeout = null;
 
 const colorModes = ['light', 'dark', 'gradient'];
-let colorModeIndex = parseInt(localStorage.getItem('colorMode') || '0', 10);
+let colorModeIndex = parseInt(localStorage.getItem('colorMode') || '1', 10);
 
 function updateGradientColor(color) {
   if (document.body.classList.contains('gradient-mode')) {

--- a/versus.html
+++ b/versus.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="versus-white">
+<body class="versus-blue">
   <nav id="top-nav">
     <a href="index.html">home</a>
     <a href="fun.html">fun</a>


### PR DESCRIPTION
## Summary
- Make gradient theme use the same blue background and navbar as versus
- Default color scheme to dark on startup
- Set versus page to use blue theme by default

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68935a5824d88325ae319dcb95c0185d