### PR TITLE
Implement matchmaking flow for versus mode and adjust timing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -46,6 +46,12 @@ body.versus-blue #top-nav a {
   color: #fff;
 }
 
+body.versus-blue,
+body.versus-white {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 body.dark-mode #pt,
 body.dark-mode #texto-exibicao,
 body.dark-mode #resultado,
@@ -677,6 +683,30 @@ body.dark-mode #clock {
   right: 0;
   text-align: center;
   padding: 4px 0;
+}
+
+#matchmaking {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(to bottom, #40e0d0, #0066cc);
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 24px;
+  text-align: center;
+  z-index: 1000;
+}
+
+#matchmaking img {
+  width: 150px;
+  height: 150px;
+  margin-bottom: 20px;
 }
 
 .dissolve {

--- a/js/versus.js
+++ b/js/versus.js
@@ -199,7 +199,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('mode-list').style.display = 'none';
     if (modo === 3) {
       botAtual = botsData[Math.floor(Math.random() * botsData.length)];
-      showConnecting(() => initGame());
+      matchmakingSequence(() => initGame());
     } else if (modo === 1) {
       botAtual = null;
       initGame();
@@ -209,22 +209,36 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function showConnecting(callback) {
-    const connect = document.getElementById('versus-connect');
-    const img = document.getElementById('versus-connect-img');
-    const txt = document.getElementById('versus-connect-text');
-    connect.style.display = 'block';
-    img.src = 'https://giffiles.alphacoders.com/209/209663.gif';
-    txt.textContent = 'estamos conectando um jogador';
-    const wait = 4000 + Math.random() * 6000;
+  function matchmakingSequence(callback) {
+    const overlay = document.getElementById('matchmaking');
+    const txt = document.getElementById('matchmaking-text');
+    const avatar = document.getElementById('matchmaking-avatar');
+    overlay.style.display = 'flex';
+    avatar.style.display = 'none';
+    txt.textContent = 'procurando um jogador online...';
+    const findSound = new Audio('gamesounds/finding.mp3');
+    findSound.play();
+    const wait = 5000 + Math.random() * 5000;
     setTimeout(() => {
-      img.src = 'https://i.pinimg.com/originals/89/86/fe/8986fef7a58272135c7c5d006a312554.gif';
-      txt.textContent = 'jogador encontrado, clique para iniciar jogo';
-      img.style.cursor = 'pointer';
-      img.addEventListener('click', () => {
-        connect.style.display = 'none';
-        callback();
-      }, { once: true });
+      const connectSound = new Audio('gamesounds/connected.wav');
+      connectSound.play();
+      avatar.src = `users/${botAtual.file}`;
+      avatar.style.display = 'block';
+      let count = 5;
+      function step() {
+        if (count > 3) {
+          txt.textContent = 'adversario encontrado';
+        } else if (count > 0) {
+          txt.textContent = String(count);
+        } else {
+          overlay.style.display = 'none';
+          callback();
+          return;
+        }
+        count--;
+        setTimeout(step, 1000);
+      }
+      step();
     }, wait);
   }
 
@@ -444,6 +458,8 @@ document.addEventListener('DOMContentLoaded', () => {
     userTimePerc = Math.max(0, 100 - avg * 20);
     userTimePerc = Math.min(userTimePerc + 22, 100);
     userTimePerc *= 0.92;
+    userTimePerc *= 1.1;
+    userTimePerc = Math.min(userTimePerc, 100);
     const vary = v => v * (1 + (Math.random() * 0.25 - 0.15));
     setBar(document.querySelector('#player-user .time .fill'), userTimePerc);
     setBar(document.querySelector('#player-user .acc .fill'), userAccPerc);

--- a/versus.html
+++ b/versus.html
@@ -17,6 +17,10 @@
   </nav>
   <div id="bot-list"></div>
   <div id="mode-list"></div>
+  <div id="matchmaking">
+    <img id="matchmaking-avatar" alt="adversario">
+    <div id="matchmaking-text"></div>
+  </div>
   <div id="versus-game" style="display:none;">
     <div id="players"></div>
     <div id="versus-phrase"></div>


### PR DESCRIPTION
## Summary
- add full-screen matchmaking overlay with sounds, opponent preview and countdown for versus mode 3
- enable scrolling in versus screens
- show user time with a 10% bonus

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6893980189f88325965ee52c8fc5e2a4