### PR TITLE
Add world page with additional game modes

### DIFF
--- a/custom.html
+++ b/custom.html
@@ -14,6 +14,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="world.html">world</a>
   </nav>
   <div id="custom-content" style="text-align:center;margin-top:50px;"></div>
   <script>

--- a/fun.html
+++ b/fun.html
@@ -14,6 +14,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="world.html">world</a>
   </nav>
   <div id="fun-content" style="text-align:center;margin-top:50px;"></div>
   <script>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="world.html">world</a>
   </nav>
     <div id="ilife-screen">
       <img id="ilife-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">

--- a/play.html
+++ b/play.html
@@ -14,6 +14,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="world.html">world</a>
   </nav>
   <div id="play-content" style="text-align:center;margin-top:50px;"></div>
   <div id="versus-stats" style="display:none;text-align:center;margin-top:50px;">

--- a/versus.html
+++ b/versus.html
@@ -14,6 +14,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="world.html">world</a>
   </nav>
   <div id="bot-list"></div>
   <div id="mode-list"></div>

--- a/world.html
+++ b/world.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>World</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="dark-mode">
+  <nav id="top-nav">
+    <a href="index.html">home</a>
+    <a href="fun.html">fun</a>
+    <a href="play.html">play</a>
+    <a href="custom.html">custom</a>
+    <a href="versus.html">versus</a>
+    <a href="world.html">world</a>
+  </nav>
+  <div id="menu">
+    <div id="menu-modes">
+      <img src="selos%20modos%20de%20jogo/modo7.png" data-mode="7" alt="Modo 7">
+      <img src="selos%20modos%20de%20jogo/modo8.png" data-mode="8" alt="Modo 8">
+      <img src="selos%20modos%20de%20jogo/modo9.png" data-mode="9" alt="Modo 9">
+      <img src="selos%20modos%20de%20jogo/modo10.png" data-mode="10" alt="Modo 10">
+      <img src="selos%20modos%20de%20jogo/modo11.png" data-mode="11" alt="Modo 11">
+      <img src="selos%20modos%20de%20jogo/modo12.png" data-mode="12" alt="Modo 12">
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add World page duplicating menu for modes 7-12
- include World link in top navigation across site

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6893fb01c60c83259671e402b183486b