### PR TITLE
Implement world mode 7 with voice-image matching

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,6 +52,51 @@ body.versus-white {
   overflow-x: hidden;
 }
 
+body.world-black {
+  background: #000;
+  color: #fff;
+}
+
+body.world-black #top-nav {
+  background: linear-gradient(90deg, #006666, #008080);
+}
+
+body.world-black #top-nav a {
+  color: #fff;
+}
+
+body.world-white {
+  background: linear-gradient(to bottom, #ffffff, #d0d0d0);
+  color: #555;
+}
+
+body.world-white #top-nav {
+  background: linear-gradient(90deg, #e0e0e0, #f5f5f5);
+}
+
+body.world-white #top-nav a {
+  color: #555;
+}
+
+body.world-blue {
+  background: linear-gradient(to bottom, #40e0d0, #0066cc);
+  color: #fff;
+}
+
+body.world-blue #top-nav {
+  background: linear-gradient(90deg, #40e0d0, #0066cc);
+}
+
+body.world-blue #top-nav a {
+  color: #fff;
+}
+
+body.world-blue,
+body.world-white {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 body.dark-mode #pt,
 body.dark-mode #texto-exibicao,
 body.dark-mode #resultado,

--- a/js/world.js
+++ b/js/world.js
@@ -1,0 +1,92 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const menu = document.getElementById('menu');
+  const game = document.getElementById('world-game');
+  const imgEl = document.getElementById('world-image');
+  const resultEl = document.getElementById('world-result');
+  const modeButtons = document.querySelectorAll('#menu-modes img');
+
+  const themes = ['black', 'white', 'blue'];
+  let theme = localStorage.getItem('menuColor') || 'black';
+
+  function applyTheme() {
+    document.body.classList.remove('world-black', 'world-white', 'world-blue');
+    document.body.classList.add(`world-${theme}`);
+  }
+
+  function cycleTheme() {
+    const idx = themes.indexOf(theme);
+    theme = themes[(idx + 1) % themes.length];
+    localStorage.setItem('menuColor', theme);
+    applyTheme();
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key.toLowerCase() === 'h') {
+      cycleTheme();
+    }
+  });
+
+  applyTheme();
+
+  let images = [];
+  let currentExpected = '';
+  let recognition;
+
+  async function loadImages() {
+    const resp = await fetch('/photos/list');
+    images = await resp.json();
+  }
+
+  function normalize(text) {
+    return text
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]/g, '');
+  }
+
+  function checkAnswer(transcript) {
+    const correct = normalize(transcript) === normalize(currentExpected);
+    resultEl.textContent = correct ? 'correto' : 'errado';
+    setTimeout(() => {
+      resultEl.textContent = '';
+      nextImage();
+    }, 1000);
+  }
+
+  function nextImage() {
+    if (!images.length) return;
+    const file = images[Math.floor(Math.random() * images.length)];
+    currentExpected = (file.split('#')[1] || '').replace(/\.[^.]+$/, '');
+    imgEl.style.opacity = 0;
+    imgEl.src = 'photos/' + encodeURIComponent(file);
+    setTimeout(() => {
+      imgEl.style.opacity = 1;
+    }, 50);
+    if (recognition) recognition.start();
+  }
+
+  if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    recognition = new SR();
+    recognition.lang = 'en-US';
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.onresult = (event) => {
+      const transcript = event.results[0][0].transcript.trim();
+      checkAnswer(transcript);
+    };
+  }
+
+  modeButtons.forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const mode = btn.getAttribute('data-mode');
+      if (mode === '7') {
+        menu.style.display = 'none';
+        game.style.display = 'block';
+        await loadImages();
+        nextImage();
+      }
+    });
+  });
+});

--- a/server.js
+++ b/server.js
@@ -1,9 +1,22 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.static(__dirname));
+
+app.get('/photos/list', (req, res) => {
+  const dir = path.join(__dirname, 'photos');
+  fs.readdir(dir, (err, files) => {
+    if (err) {
+      return res.status(500).json({ error: 'Unable to list photos' });
+    }
+    const images = files.filter(f => /\.(png|jpe?g|gif)$/i.test(f));
+    res.json(images);
+  });
+});
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);

--- a/world.html
+++ b/world.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="dark-mode">
+<body class="world-black">
   <nav id="top-nav">
     <a href="index.html">home</a>
     <a href="fun.html">fun</a>
@@ -26,5 +26,10 @@
       <img src="selos%20modos%20de%20jogo/modo12.png" data-mode="12" alt="Modo 12">
     </div>
   </div>
+  <div id="world-game" style="display:none;text-align:center;margin-top:50px;">
+    <img id="world-image" style="max-width:80%;opacity:0;transition:opacity 0.5s;" alt="">
+    <div id="world-result"></div>
+  </div>
+  <script src="js/world.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `/photos/list` endpoint to serve available images for world mode
- Support black, white, and blue themes for world mode
- Introduce world mode 7 gameplay with random photo prompts and speech recognition

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689411c2c95083259311cfc8ffd1a15a