### PR TITLE
docs: explain world mode 7

### DIFF
--- a/js/world.js
+++ b/js/world.js
@@ -1,3 +1,4 @@
+// World mode 7: show random photos with fade-in and check spoken names
 document.addEventListener('DOMContentLoaded', () => {
   const menu = document.getElementById('menu');
   const game = document.getElementById('world-game');


### PR DESCRIPTION
## Summary
- document World mode 7's random photo, fade-in, and speech-checked answers
- server exposes `/photos/list` for retrieving available images
- World page applies menu color themes and shows images for speech practice

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894141df6f48325952488f8469b4005