### PR TITLE
Rename world modes to 7-12 and add image-based mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -276,6 +276,36 @@ body.dark-mode #clock {
   transition: width 1.5s linear, background-color 1.5s linear;
 }
 
+#barra-progresso.circular {
+  width: 450px;
+  height: 450px;
+  border-radius: 50%;
+  margin: 0 auto;
+  border: 30px solid transparent;
+  position: relative;
+  transform: none;
+}
+
+#barra-progresso.circular #barra-preenchida {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  transition: none;
+  background: conic-gradient(var(--bar-color, #ff0000) calc(var(--perc, 0) * 1deg), #333 0);
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 30px), #000 calc(100% - 30px));
+          mask: radial-gradient(farthest-side, transparent calc(100% - 30px), #000 calc(100% - 30px));
+}
+
+#barra-progresso.circular #imagem-modo7 {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 350px;
+  height: 350px;
+  transform: translate(-50%, -50%);
+  object-fit: contain;
+}
+
 #mode-stats,
 #texto-exibicao,
 #barra-progresso {

--- a/world.html
+++ b/world.html
@@ -29,12 +29,12 @@
   <img id="tutorial-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" style="display:none" />
   <div id="menu" style="display:none">
     <div id="menu-modes">
-      <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
-      <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">
-      <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" alt="Modo 3">
-      <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" alt="Modo 4">
-      <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" alt="Modo 5">
-      <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" alt="Modo 6">
+      <img src="selos%20modos%20de%20jogo/modo7.png" data-mode="1" alt="Modo 7">
+      <img src="selos%20modos%20de%20jogo/modo8.png" data-mode="2" alt="Modo 8">
+      <img src="selos%20modos%20de%20jogo/modo9.png" data-mode="3" alt="Modo 9">
+      <img src="selos%20modos%20de%20jogo/modo10.png" data-mode="4" alt="Modo 10">
+      <img src="selos%20modos%20de%20jogo/modo11.png" data-mode="5" alt="Modo 11">
+      <img src="selos%20modos%20de%20jogo/modo12.png" data-mode="6" alt="Modo 12">
     </div>
   </div>
 
@@ -50,6 +50,7 @@
     <div id="texto-exibicao"></div>
     <div id="barra-progresso">
       <div id="barra-preenchida"></div>
+      <img id="imagem-modo7" alt="Imagem do modo 7" style="display:none" />
     </div>
     <div id="pt-container">
       <textarea id="pt" rows="1" readonly></textarea>
@@ -59,17 +60,17 @@
     <div id="resultado"></div>
     <div id="acertos"></div>
     <div id="mode-buttons">
-      <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" class="mode-btn" alt="Modo 1" />
-      <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" class="mode-btn" alt="Modo 2" />
-      <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" class="mode-btn" alt="Modo 3" />
-      <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" class="mode-btn" alt="Modo 4" />
-      <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" class="mode-btn" alt="Modo 5" />
-      <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" class="mode-btn" alt="Modo 6" />
+      <img src="selos%20modos%20de%20jogo/modo7.png" data-mode="1" class="mode-btn" alt="Modo 7" />
+      <img src="selos%20modos%20de%20jogo/modo8.png" data-mode="2" class="mode-btn" alt="Modo 8" />
+      <img src="selos%20modos%20de%20jogo/modo9.png" data-mode="3" class="mode-btn" alt="Modo 9" />
+      <img src="selos%20modos%20de%20jogo/modo10.png" data-mode="4" class="mode-btn" alt="Modo 10" />
+      <img src="selos%20modos%20de%20jogo/modo11.png" data-mode="5" class="mode-btn" alt="Modo 11" />
+      <img src="selos%20modos%20de%20jogo/modo12.png" data-mode="6" class="mode-btn" alt="Modo 12" />
     </div>
   </div>
 
   <div id="intro-overlay" style="display:none">
-    <img id="intro-image" src="selos%20modos%20de%20jogo/modo1.png" alt="Modo 1">
+    <img id="intro-image" src="selos%20modos%20de%20jogo/modo7.png" alt="Modo 7">
     <div id="intro-progress">
       <div id="intro-progress-filled"></div>
     </div>


### PR DESCRIPTION
## Summary
- Renamed world mode icons to show modes 7–12 and added image container for mode 7
- Introduced circular progress ring with center image support and updated progress logic
- Loaded random images from photos folder for new mode 7 using filename-based translations

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68941f51c4208325bf56fd46b47bb95f