### PR TITLE
Add Explore page with color overlays

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -787,3 +787,27 @@ body.dark-mode #clock {
   }
 }
 
+
+.explore-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  max-width: 600px;
+  margin: 20px auto;
+}
+
+.explore-grid img {
+  width: 100%;
+  cursor: pointer;
+}
+
+#color-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  z-index: 1000;
+}
+

--- a/custom.html
+++ b/custom.html
@@ -14,6 +14,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="explore.html">explore</a>
   </nav>
   <div id="custom-content" style="text-align:center;margin-top:50px;"></div>
   <script>

--- a/explore.html
+++ b/explore.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Explore</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="dark-mode">
+  <nav id="top-nav">
+    <a href="index.html">home</a>
+    <a href="fun.html">fun</a>
+    <a href="play.html">play</a>
+    <a href="custom.html">custom</a>
+    <a href="versus.html">versus</a>
+    <a href="explore.html">explore</a>
+  </nav>
+  <div class="explore-grid">
+    <img src="selos%20modos%20de%20jogo/modo7.png" alt="Modo 7" data-color="#ffffff">
+    <img src="selos%20modos%20de%20jogo/modo8.png" alt="Modo 8" data-color="#FFD700">
+    <img src="selos%20modos%20de%20jogo/modo9.png" alt="Modo 9" data-color="#000000">
+    <img src="selos%20modos%20de%20jogo/modo10.png" alt="Modo 10" data-color="#00008B">
+    <img src="selos%20modos%20de%20jogo/modo11.png" alt="Modo 11" data-color="#D3D3D3">
+    <img src="selos%20modos%20de%20jogo/modo12.png" alt="Modo 12" data-color="#40E0D0">
+  </div>
+  <div id="color-screen"></div>
+  <script>
+    document.querySelectorAll('.explore-grid img').forEach(img => {
+      img.addEventListener('click', () => {
+        const overlay = document.getElementById('color-screen');
+        overlay.style.backgroundColor = img.dataset.color;
+        overlay.style.display = 'block';
+      });
+    });
+    document.getElementById('color-screen').addEventListener('click', function() {
+      this.style.display = 'none';
+    });
+  </script>
+</body>
+</html>

--- a/fun.html
+++ b/fun.html
@@ -14,6 +14,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="explore.html">explore</a>
   </nav>
   <div id="fun-content"></div>
   <script>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="explore.html">explore</a>
   </nav>
     <div id="ilife-screen">
       <img id="ilife-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">

--- a/play.html
+++ b/play.html
@@ -14,6 +14,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="explore.html">explore</a>
   </nav>
   <div id="play-content" style="text-align:center;margin-top:50px;"></div>
   <div id="versus-stats" style="display:none;text-align:center;margin-top:50px;">

--- a/versus.html
+++ b/versus.html
@@ -14,6 +14,7 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
     <a href="versus.html">versus</a>
+    <a href="explore.html">explore</a>
   </nav>
   <div id="bot-list"></div>
   <div id="mode-list"></div>


### PR DESCRIPTION
## Summary
- add Explore page with six mode icons that display full-screen colors when clicked
- include styles for explore grid and overlay screen
- link Explore page from header navigation across the site

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894656a41108325b82c73b0bc6e62d9