### PR TITLE
Add white overlay for photo slideshow

### DIFF
--- a/css/photos.css
+++ b/css/photos.css
@@ -1,6 +1,5 @@
 body {
   margin: 0;
-  background-color: #fff;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -8,6 +7,17 @@ body {
   min-height: 100vh;
   font-family: 'Open Sans', sans-serif;
   color: #000;
+  position: relative;
+}
+
+#background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #fff;
+  z-index: -1;
 }
 
 #slideshow-image {

--- a/photos.html
+++ b/photos.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="css/photos.css" />
 </head>
 <body>
+  <div id="background"></div>
   <div id="photo-wrapper">
     <img id="slideshow-image" alt="Imagem aleatória" />
     <div id="image-name"></div>


### PR DESCRIPTION
## Summary
- add fixed white background layer behind photo slideshow
- ensure photo and caption appear above background

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68946c3466048325b94e0d30b905919e