### PR TITLE
feat: add explore mode7 countdown

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -811,3 +811,13 @@ body.dark-mode #clock {
   z-index: 1000;
 }
 
+#countdown {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 2rem;
+  color: #000;
+  font-weight: bold;
+  display: none;
+}
+

--- a/explore.html
+++ b/explore.html
@@ -25,17 +25,6 @@
     <img src="selos%20modos%20de%20jogo/modo12.png" alt="Modo 12" data-color="#40E0D0">
   </div>
   <div id="color-screen"></div>
-  <script>
-    document.querySelectorAll('.explore-grid img').forEach(img => {
-      img.addEventListener('click', () => {
-        const overlay = document.getElementById('color-screen');
-        overlay.style.backgroundColor = img.dataset.color;
-        overlay.style.display = 'block';
-      });
-    });
-    document.getElementById('color-screen').addEventListener('click', function() {
-      this.style.display = 'none';
-    });
-  </script>
+  <script src="js/explore.js"></script>
 </body>
 </html>

--- a/js/explore.js
+++ b/js/explore.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const overlay = document.getElementById('color-screen');
+  const countdownEl = document.createElement('div');
+  countdownEl.id = 'countdown';
+  overlay.appendChild(countdownEl);
+
+  let countdownInterval = null;
+
+  function hideOverlay() {
+    overlay.style.display = 'none';
+    countdownEl.style.display = 'none';
+    if (countdownInterval) {
+      clearInterval(countdownInterval);
+      countdownInterval = null;
+    }
+    overlay.onclick = null;
+  }
+
+  function showOverlay(color, isMode7) {
+    overlay.style.backgroundColor = color;
+    overlay.style.display = 'block';
+
+    if (isMode7) {
+      let timeLeft = 10;
+      countdownEl.textContent = timeLeft;
+      countdownEl.style.display = 'block';
+
+      countdownInterval = setInterval(() => {
+        timeLeft--;
+        countdownEl.textContent = timeLeft;
+        if (timeLeft <= 0) {
+          hideOverlay();
+        }
+      }, 1000);
+
+      overlay.onclick = null;
+    } else {
+      countdownEl.style.display = 'none';
+      overlay.onclick = hideOverlay;
+    }
+  }
+
+  document.querySelectorAll('.explore-grid img').forEach(img => {
+    img.addEventListener('click', () => {
+      const isMode7 = img.alt.includes('Modo 7');
+      showOverlay(img.dataset.color, isMode7);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- move explore page logic into new JS module
- add 10s countdown overlay for Mode 7
- disable click-to-exit for Mode 7 and hide after timer

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6894a7afb6cc8325ae064de54b675cb4