### PR TITLE
Refine time metric scaling per mode

### DIFF
--- a/custom.html
+++ b/custom.html
@@ -51,6 +51,7 @@
         <div class="custom-info">Velocidade: ${vsStats.speed || 0}%</div>
       `;
       container.appendChild(vsSection);
+      const TIME_POINT_REFS = { 1:125, 2:124, 3:126, 4:105, 5:100, 6:120 };
       const statsData = JSON.parse(localStorage.getItem('modeStats') || '{}');
       for (let i = 1; i <= 6; i++) {
         const stats = statsData[i] || {};
@@ -62,7 +63,8 @@
         const acc = total ? ((correct / total) * 100).toFixed(2) : '0';
         const avg = total ? formatTime(totalTime / total) : '0s';
         const timePts = stats.timePoints || 0;
-        const avgPts = total ? (timePts / total).toFixed(2) : '0';
+        const ref = TIME_POINT_REFS[i] || 100;
+        const avgPts = total ? ((timePts / total) / ref * 100).toFixed(2) : '0';
         const reportPerc = total ? ((report / total) * 100).toFixed(2) : '0';
         const section = document.createElement('div');
         section.innerHTML = `

--- a/js/main.js
+++ b/js/main.js
@@ -245,6 +245,15 @@ const timeScoreBases = {
   6: {6: [2.36, 5.78], 33: [3.84, 8.03]}
 };
 
+const TIME_POINT_REFS = {
+  1: 125,
+  2: 124,
+  3: 126,
+  4: 105,
+  5: 100,
+  6: 120
+};
+
 function getTimeMetrics(len, mode) {
   const base = timeScoreBases[mode];
   if (!base) return { perfect: 0, worst: 0 };
@@ -794,7 +803,8 @@ function calcModeStats(mode) {
   const timePts = stats.timePoints || 0;
   const accPerc = total ? (correct / total * 100) : 0;
   const avg = total ? (totalTime / total / 1000) : 0;
-  const timePerc = total ? (timePts / total) : 0;
+  const ref = TIME_POINT_REFS[mode] || 100;
+  const timePerc = total ? ((timePts / total) / ref) * 100 : 0;
   const notReportPerc = total ? (100 - (report / total * 100)) : 100;
   return { accPerc, timePerc, avg, notReportPerc };
 }
@@ -1389,7 +1399,8 @@ function verificarResposta() {
   if (selectedMode >= 2) {
     const { perfect, worst } = getTimeMetrics(phraseLen, selectedMode);
     const elapsedSec = elapsed / 1000;
-    timePoints = ((worst - elapsedSec) / (worst - perfect)) * 100;
+    const ref = TIME_POINT_REFS[selectedMode] || 100;
+    timePoints = ((worst - elapsedSec) / (worst - perfect)) * ref;
     if (timePoints < 0) timePoints = 0;
   }
 
@@ -1499,9 +1510,10 @@ function finishMode() {
     const total = stats6.totalPhrases || 0;
     const acc = total ? (stats6.correct / total * 100).toFixed(2) : '0';
     const avgPts = total ? (stats6.timePoints / total) : 0;
+    const speedPerc = (avgPts / (TIME_POINT_REFS[6] || 100)) * 100;
     const reportPerc = total ? (stats6.report / total * 100).toFixed(2) : '0';
     const details = JSON.parse(localStorage.getItem('levelDetails') || '[]');
-    details.push({ level: pastaAtual + 1, accuracy: acc, speed: avgPts.toFixed(2), reports: reportPerc });
+    details.push({ level: pastaAtual + 1, accuracy: acc, speed: speedPerc.toFixed(2), reports: reportPerc });
     localStorage.setItem('levelDetails', JSON.stringify(details));
     document.querySelectorAll('#menu-modes img[data-mode="6"], #mode-buttons img[data-mode="6"]').forEach(img => {
       img.src = 'selos%20modos%20de%20jogo/modostar.png';

--- a/js/play.js
+++ b/js/play.js
@@ -96,6 +96,14 @@ function createStatCircle(perc, label, iconSrc, extraText) {
   }
   return wrapper;
 }
+const TIME_POINT_REFS = {
+  1: 125,
+  2: 124,
+  3: 126,
+  4: 105,
+  5: 100,
+  6: 120
+};
 
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('play-content');
@@ -123,7 +131,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const timePts = stats.timePoints || 0;
     const accPerc = total ? (correct / total * 100) : 0;
     const avg = total ? (totalTime / total / 1000) : 0;
-    const timePerc = total ? (timePts / total) : 0;
+    const ref = TIME_POINT_REFS[mode] || 100;
+    const timePerc = total ? ((timePts / total) / ref) * 100 : 0;
     const notReportPerc = total ? (100 - (report / total * 100)) : 100;
     return { accPerc, timePerc, avg, notReportPerc };
   }


### PR DESCRIPTION
## Summary
- Map new time-point references for each game mode
- Scale recorded time points and stats using per-mode references
- Normalize custom stats page with the same time-point scaling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894f25121e883258275588b9a602a7c