### PR TITLE
Refactor versus mode to display real-time ranking

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -611,6 +611,14 @@ body.dark-mode #clock {
   margin-left:auto;
   margin-right:auto;
 }
+#versus-ranking {
+  margin-top:20px;
+  display:flex;
+  flex-direction:column;
+  width:fit-content;
+  margin-left:auto;
+  margin-right:auto;
+}
 .ranking-row {
   display:flex;
   align-items:center;
@@ -632,6 +640,13 @@ body.dark-mode #clock {
   font-weight:700;
   font-size:25px;
   font-family:'Open Sans', sans-serif;
+}
+.rank-hits,
+.rank-errors {
+  font-weight:700;
+  font-size:15px;
+  font-family:'Open Sans', sans-serif;
+  margin-left:10px;
 }
 
 #bot-list {

--- a/versus.html
+++ b/versus.html
@@ -23,9 +23,8 @@
     <div id="matchmaking-text"></div>
   </div>
   <div id="versus-game" style="display:none;">
-    <div id="players"></div>
     <div id="versus-phrase"></div>
-    <div id="ranking-bottom"></div>
+    <div id="versus-ranking"></div>
   </div>
   <script src="js/versus.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- replace versus mode layout with list-based ranking
- compute and update scores for up to 10 players in real time
- style ranking rows and container

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894f57d913c8325aff56d5985cd1182