### PR TITLE
Recalibrate speed metric and adjust time points

### DIFF
--- a/custom.html
+++ b/custom.html
@@ -43,12 +43,25 @@
     }
     document.addEventListener('DOMContentLoaded', () => {
       const container = document.getElementById('custom-content');
+      const SPEED_FACTOR = 50 / 81.72;
+      const scaleSpeed = v => v * SPEED_FACTOR;
+      function adjustTimePoints(mode, value) {
+        const mapping = { 2: {125: 95}, 3: {126: 95}, 4: {110: 100}, 6: {120: 95} };
+        const m = mapping[mode];
+        if (m) {
+          const rounded = Math.round(value);
+          if (m[rounded] !== undefined) return m[rounded];
+        }
+        return value;
+      }
       const vsStats = JSON.parse(localStorage.getItem('versusStats') || '{}');
+      const rawSpeed = vsStats.speed || 0;
+      const speed = (rawSpeed > 61 ? scaleSpeed(rawSpeed) : rawSpeed).toFixed(2);
       const vsSection = document.createElement('div');
       vsSection.innerHTML = `
         <h1 class="custom-title">Versus - Estatísticas</h1>
         <div class="custom-info">Precisão: ${vsStats.accuracy || 0}%</div>
-        <div class="custom-info">Velocidade: ${vsStats.speed || 0}%</div>
+        <div class="custom-info">Velocidade: ${speed}%</div>
       `;
       container.appendChild(vsSection);
       const TIME_POINT_REFS = { 1:125, 2:124, 3:126, 4:105, 5:100, 6:120 };
@@ -64,7 +77,9 @@
         const avg = total ? formatTime(totalTime / total) : '0s';
         const timePts = stats.timePoints || 0;
         const ref = TIME_POINT_REFS[i] || 100;
-        const avgPts = total ? ((timePts / total) / ref * 100).toFixed(2) : '0';
+        let avgPts = total ? ((timePts / total) / ref * 100) : 0;
+        avgPts = adjustTimePoints(i, avgPts);
+        const avgPtsStr = avgPts.toFixed(2);
         const reportPerc = total ? ((report / total) * 100).toFixed(2) : '0';
         const section = document.createElement('div');
         section.innerHTML = `
@@ -75,7 +90,7 @@
           <div class="custom-info">Frases erradas: ${wrong}</div>
           <div class="custom-info">Porcentagem de acertos: ${acc}%</div>
           <div class="custom-info">Média de tempo por frase: ${avg}</div>
-          <div class="custom-info">Pontos de tempo: ${avgPts}</div>
+          <div class="custom-info">Pontos de tempo: ${avgPtsStr}</div>
           <div class="custom-info">Uso de reportar: ${reportPerc}%</div>
         `;
         const red = stats.wrongRanking || [];
@@ -119,7 +134,8 @@
         table.appendChild(header);
         details.forEach(d => {
           const row = document.createElement('tr');
-          row.innerHTML = `<td>${d.level}</td><td>${d.accuracy}%</td><td>${d.speed}%</td><td>${d.reports}%</td>`;
+          const spd = (d.speed > 61 ? scaleSpeed(d.speed) : d.speed).toFixed(2);
+          row.innerHTML = `<td>${d.level}</td><td>${d.accuracy}%</td><td>${spd}%</td><td>${d.reports}%</td>`;
           table.appendChild(row);
         });
         container.appendChild(table);

--- a/fun.html
+++ b/fun.html
@@ -29,9 +29,12 @@
         const score = (avgAcc + avgTempo) / 2;
         return { name: b.name, file: b.file, score };
       });
+      const SPEED_FACTOR = 50 / 81.72;
+      const scaleSpeed = v => v * SPEED_FACTOR;
       const vsStats = JSON.parse(localStorage.getItem('versusStats') || '{}');
       const userAcc = parseFloat(vsStats.accuracy) || 0;
-      const userTempo = parseFloat(vsStats.speed) || 0;
+      let userTempo = parseFloat(vsStats.speed) || 0;
+      if (userTempo > 61) userTempo = scaleSpeed(userTempo);
       const userScore = (userAcc + userTempo) / 2;
       entries.push({ name: 'Você', file: 'theuser.png', score: userScore });
       entries.sort((a, b) => b.score - a.score);

--- a/js/main.js
+++ b/js/main.js
@@ -254,6 +254,18 @@ const TIME_POINT_REFS = {
   6: 120
 };
 
+const SPEED_FACTOR = 50 / 81.72;
+const scaleSpeed = v => v * SPEED_FACTOR;
+function adjustTimePoints(mode, value) {
+  const mapping = { 2: {125: 95}, 3: {126: 95}, 4: {110: 100}, 6: {120: 95} };
+  const m = mapping[mode];
+  if (m) {
+    const rounded = Math.round(value);
+    if (m[rounded] !== undefined) return m[rounded];
+  }
+  return value;
+}
+
 function getTimeMetrics(len, mode) {
   const base = timeScoreBases[mode];
   if (!base) return { perfect: 0, worst: 0 };
@@ -804,7 +816,9 @@ function calcModeStats(mode) {
   const accPerc = total ? (correct / total * 100) : 0;
   const avg = total ? (totalTime / total / 1000) : 0;
   const ref = TIME_POINT_REFS[mode] || 100;
-  const timePerc = total ? ((timePts / total) / ref) * 100 : 0;
+  let timePerc = total ? ((timePts / total) / ref) * 100 : 0;
+  timePerc = adjustTimePoints(mode, timePerc);
+  timePerc = scaleSpeed(timePerc);
   const notReportPerc = total ? (100 - (report / total * 100)) : 100;
   return { accPerc, timePerc, avg, notReportPerc };
 }
@@ -1510,7 +1524,9 @@ function finishMode() {
     const total = stats6.totalPhrases || 0;
     const acc = total ? (stats6.correct / total * 100).toFixed(2) : '0';
     const avgPts = total ? (stats6.timePoints / total) : 0;
-    const speedPerc = (avgPts / (TIME_POINT_REFS[6] || 100)) * 100;
+    let speedPerc = (avgPts / (TIME_POINT_REFS[6] || 100)) * 100;
+    speedPerc = adjustTimePoints(6, speedPerc);
+    speedPerc = scaleSpeed(speedPerc);
     const reportPerc = total ? (stats6.report / total * 100).toFixed(2) : '0';
     const details = JSON.parse(localStorage.getItem('levelDetails') || '[]');
     details.push({ level: pastaAtual + 1, accuracy: acc, speed: speedPerc.toFixed(2), reports: reportPerc });

--- a/js/play.js
+++ b/js/play.js
@@ -105,6 +105,18 @@ const TIME_POINT_REFS = {
   6: 120
 };
 
+const SPEED_FACTOR = 50 / 81.72;
+const scaleSpeed = v => v * SPEED_FACTOR;
+function adjustTimePoints(mode, value) {
+  const mapping = { 2: {125: 95}, 3: {126: 95}, 4: {110: 100}, 6: {120: 95} };
+  const m = mapping[mode];
+  if (m) {
+    const rounded = Math.round(value);
+    if (m[rounded] !== undefined) return m[rounded];
+  }
+  return value;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('play-content');
   container.style.transition = 'opacity 0.2s';
@@ -132,7 +144,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const accPerc = total ? (correct / total * 100) : 0;
     const avg = total ? (totalTime / total / 1000) : 0;
     const ref = TIME_POINT_REFS[mode] || 100;
-    const timePerc = total ? ((timePts / total) / ref) * 100 : 0;
+    let timePerc = total ? ((timePts / total) / ref) * 100 : 0;
+    timePerc = adjustTimePoints(mode, timePerc);
+    timePerc = scaleSpeed(timePerc);
     const notReportPerc = total ? (100 - (report / total * 100)) : 100;
     return { accPerc, timePerc, avg, notReportPerc };
   }

--- a/js/versus.js
+++ b/js/versus.js
@@ -59,6 +59,9 @@ const TIME_POINT_REFS = {
   6: 120
 };
 
+const SPEED_FACTOR = 50 / 81.72;
+const scaleSpeed = v => v * SPEED_FACTOR;
+
 let frasesCorretas = {};
 
 async function carregarFrasesCorretas() {
@@ -483,6 +486,7 @@ document.addEventListener('DOMContentLoaded', () => {
     userTimePerc *= 0.92;
     userTimePerc *= 1.1;
     userTimePerc = Math.min(userTimePerc, 100);
+    userTimePerc = scaleSpeed(userTimePerc);
     const vary = v => v * (1 + (Math.random() * 0.25 - 0.15));
     setBar(userPlayer.element.querySelector('.time .fill'), userTimePerc);
     setBar(userPlayer.element.querySelector('.acc .fill'), userAccPerc);
@@ -492,7 +496,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const userScore = userTimePts + acertos - userErrors;
     botPlayers.forEach(bp => {
       const acc = vary(bp.stats.precisao);
-      const tempo = vary(bp.stats.tempo);
+      const tempo = scaleSpeed(vary(bp.stats.tempo));
       bp.accSum += acc;
       bp.timeSum += tempo;
       bp.rounds++;


### PR DESCRIPTION
## Summary
- Re-scale speed percentages with a 50/81.72 factor for consistent velocity readings
- Map specific time point percentages to new fixed values per mode and apply them across displays

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689521b1c6408325981e3e4e429d1438