### PR TITLE
Recalibrate speed metric and time point references

### DIFF
--- a/custom.html
+++ b/custom.html
@@ -43,15 +43,17 @@
     }
     document.addEventListener('DOMContentLoaded', () => {
       const container = document.getElementById('custom-content');
+      const SPEED_SCALE = 70 / 81.72;
       const vsStats = JSON.parse(localStorage.getItem('versusStats') || '{}');
+      const vsSpeed = vsStats.scaled ? vsStats.speed : (vsStats.speed ? (vsStats.speed * SPEED_SCALE).toFixed(2) : 0);
       const vsSection = document.createElement('div');
       vsSection.innerHTML = `
         <h1 class="custom-title">Versus - Estatísticas</h1>
         <div class="custom-info">Precisão: ${vsStats.accuracy || 0}%</div>
-        <div class="custom-info">Velocidade: ${vsStats.speed || 0}%</div>
+        <div class="custom-info">Velocidade: ${vsSpeed || 0}%</div>
       `;
       container.appendChild(vsSection);
-      const TIME_POINT_REFS = { 1:125, 2:124, 3:126, 4:105, 5:100, 6:120 };
+      const TIME_POINT_REFS = { 1:125, 2:95, 3:95, 4:100, 5:100, 6:95 };
       const statsData = JSON.parse(localStorage.getItem('modeStats') || '{}');
       for (let i = 1; i <= 6; i++) {
         const stats = statsData[i] || {};
@@ -64,7 +66,7 @@
         const avg = total ? formatTime(totalTime / total) : '0s';
         const timePts = stats.timePoints || 0;
         const ref = TIME_POINT_REFS[i] || 100;
-        const avgPts = total ? ((timePts / total) / ref * 100).toFixed(2) : '0';
+        const avgPts = total ? (((timePts / total) / ref * 100) * SPEED_SCALE).toFixed(2) : '0';
         const reportPerc = total ? ((report / total) * 100).toFixed(2) : '0';
         const section = document.createElement('div');
         section.innerHTML = `
@@ -119,7 +121,8 @@
         table.appendChild(header);
         details.forEach(d => {
           const row = document.createElement('tr');
-          row.innerHTML = `<td>${d.level}</td><td>${d.accuracy}%</td><td>${d.speed}%</td><td>${d.reports}%</td>`;
+          const spd = d.scaled ? d.speed : (d.speed ? (d.speed * SPEED_SCALE).toFixed(2) : d.speed);
+          row.innerHTML = `<td>${d.level}</td><td>${d.accuracy}%</td><td>${spd}%</td><td>${d.reports}%</td>`;
           table.appendChild(row);
         });
         container.appendChild(table);

--- a/fun.html
+++ b/fun.html
@@ -29,9 +29,11 @@
         const score = (avgAcc + avgTempo) / 2;
         return { name: b.name, file: b.file, score };
       });
+      const SPEED_SCALE = 70 / 81.72;
       const vsStats = JSON.parse(localStorage.getItem('versusStats') || '{}');
       const userAcc = parseFloat(vsStats.accuracy) || 0;
-      const userTempo = parseFloat(vsStats.speed) || 0;
+      let userTempo = parseFloat(vsStats.speed) || 0;
+      if (!vsStats.scaled) userTempo *= SPEED_SCALE;
       const userScore = (userAcc + userTempo) / 2;
       entries.push({ name: 'Você', file: 'theuser.png', score: userScore });
       entries.sort((a, b) => b.score - a.score);

--- a/js/main.js
+++ b/js/main.js
@@ -247,12 +247,14 @@ const timeScoreBases = {
 
 const TIME_POINT_REFS = {
   1: 125,
-  2: 124,
-  3: 126,
-  4: 105,
+  2: 95,
+  3: 95,
+  4: 100,
   5: 100,
-  6: 120
+  6: 95
 };
+
+const SPEED_SCALE = 70 / 81.72;
 
 function getTimeMetrics(len, mode) {
   const base = timeScoreBases[mode];
@@ -804,7 +806,8 @@ function calcModeStats(mode) {
   const accPerc = total ? (correct / total * 100) : 0;
   const avg = total ? (totalTime / total / 1000) : 0;
   const ref = TIME_POINT_REFS[mode] || 100;
-  const timePerc = total ? ((timePts / total) / ref) * 100 : 0;
+  let timePerc = total ? ((timePts / total) / ref) * 100 : 0;
+  timePerc *= SPEED_SCALE;
   const notReportPerc = total ? (100 - (report / total * 100)) : 100;
   return { accPerc, timePerc, avg, notReportPerc };
 }
@@ -1510,10 +1513,10 @@ function finishMode() {
     const total = stats6.totalPhrases || 0;
     const acc = total ? (stats6.correct / total * 100).toFixed(2) : '0';
     const avgPts = total ? (stats6.timePoints / total) : 0;
-    const speedPerc = (avgPts / (TIME_POINT_REFS[6] || 100)) * 100;
+    const speedPerc = ((avgPts / (TIME_POINT_REFS[6] || 100)) * 100) * SPEED_SCALE;
     const reportPerc = total ? (stats6.report / total * 100).toFixed(2) : '0';
     const details = JSON.parse(localStorage.getItem('levelDetails') || '[]');
-    details.push({ level: pastaAtual + 1, accuracy: acc, speed: speedPerc.toFixed(2), reports: reportPerc });
+    details.push({ level: pastaAtual + 1, accuracy: acc, speed: speedPerc.toFixed(2), reports: reportPerc, scaled: true });
     localStorage.setItem('levelDetails', JSON.stringify(details));
     document.querySelectorAll('#menu-modes img[data-mode="6"], #mode-buttons img[data-mode="6"]').forEach(img => {
       img.src = 'selos%20modos%20de%20jogo/modostar.png';

--- a/js/play.js
+++ b/js/play.js
@@ -98,12 +98,14 @@ function createStatCircle(perc, label, iconSrc, extraText) {
 }
 const TIME_POINT_REFS = {
   1: 125,
-  2: 124,
-  3: 126,
-  4: 105,
+  2: 95,
+  3: 95,
+  4: 100,
   5: 100,
-  6: 120
+  6: 95
 };
+
+const SPEED_SCALE = 70 / 81.72;
 
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('play-content');
@@ -132,7 +134,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const accPerc = total ? (correct / total * 100) : 0;
     const avg = total ? (totalTime / total / 1000) : 0;
     const ref = TIME_POINT_REFS[mode] || 100;
-    const timePerc = total ? ((timePts / total) / ref) * 100 : 0;
+    let timePerc = total ? ((timePts / total) / ref) * 100 : 0;
+    timePerc *= SPEED_SCALE;
     const notReportPerc = total ? (100 - (report / total * 100)) : 100;
     return { accPerc, timePerc, avg, notReportPerc };
   }

--- a/js/versus.js
+++ b/js/versus.js
@@ -52,12 +52,14 @@ function colorFromPercent(perc) {
 
 const TIME_POINT_REFS = {
   1: 125,
-  2: 124,
-  3: 126,
-  4: 105,
+  2: 95,
+  3: 95,
+  4: 100,
   5: 100,
-  6: 120
+  6: 95
 };
+
+const SPEED_SCALE = 70 / 81.72;
 
 let frasesCorretas = {};
 
@@ -483,6 +485,7 @@ document.addEventListener('DOMContentLoaded', () => {
     userTimePerc *= 0.92;
     userTimePerc *= 1.1;
     userTimePerc = Math.min(userTimePerc, 100);
+    userTimePerc *= SPEED_SCALE;
     const vary = v => v * (1 + (Math.random() * 0.25 - 0.15));
     setBar(userPlayer.element.querySelector('.time .fill'), userTimePerc);
     setBar(userPlayer.element.querySelector('.acc .fill'), userAccPerc);
@@ -532,7 +535,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const userTimePts = (userTimePerc / 100) * ref * totalFrases;
     const userErrors = totalFrases - acertos;
     const userScore = userTimePts + acertos - userErrors;
-    localStorage.setItem('versusStats', JSON.stringify({ accuracy: userAccPerc.toFixed(2), speed: userTimePerc.toFixed(2) }));
+    localStorage.setItem('versusStats', JSON.stringify({ accuracy: userAccPerc.toFixed(2), speed: userTimePerc.toFixed(2), scaled: true }));
     const botScores = botPlayers.map(bp => {
       const timePts = (bp.tempo / 100) * ref * bp.rounds;
       const corr = (bp.acc / 100) * bp.rounds;


### PR DESCRIPTION
## Summary
- Rescaled user "Velocidade (%)" metric with a proportional factor so 81.72% becomes 70%, updating mode stats and versus results
- Adjusted time point reference values for modes 2, 3, 4 and 6 and applied scaling across custom and play pages
- Updated custom and ranking pages to use new scaling and mark stored stats as calibrated

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68952d7d4ca48325a31ec99ed9aa6a40