### PR TITLE
Improve mobile responsiveness and add voice input toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/css/style.css
+++ b/css/style.css
@@ -156,14 +156,15 @@ body.dark-mode #clock {
 
 #menu-modes {
   display: grid;
-  grid-template-columns: repeat(3, 227px);
-  grid-auto-rows: 227px;
-  gap: 50px;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 20px;
+  width: 100%;
+  max-width: 90vw;
 }
 
 #menu-modes img {
-  width: 227px;
-  height: 227px;
+  width: 100%;
+  height: auto;
   object-fit: contain;
   cursor: pointer;
   opacity: 0.3;
@@ -379,8 +380,9 @@ body.dark-mode #clock {
 }
 
 #mode-buttons img {
-  width: 117px;
-  height: 117px;
+  width: 15vw;
+  max-width: 117px;
+  height: auto;
   cursor: pointer;
   opacity: 0.35;
   transition: opacity 0.2s linear;
@@ -403,15 +405,6 @@ body.dark-mode #clock {
     font-size: 12vw;
   }
 
-  #menu-modes {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
-  }
-
-  #menu-modes img {
-    width: 36.4vw;
-    height: 36.4vw;
-  }
 }
 
 @keyframes mode1Zoom {
@@ -847,5 +840,35 @@ body.dark-mode #clock {
   color: #000;
   font-weight: bold;
   display: none;
+}
+
+#mic-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: none;
+  background: #00b3b3;
+  color: #fff;
+  font-size: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+#mic-button.active {
+  background: #ff0000;
+}
+
+@media (max-width: 600px) {
+  #mic-button {
+    width: 50px;
+    height: 50px;
+    font-size: 20px;
+  }
 }
 

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
     </div>
   </div>
 
+  <button id="mic-button" aria-label="Ativar microfone">🎤</button>
 
   <div id="visor">
     <!-- conteúdo visual aqui -->
@@ -58,15 +59,15 @@
     <div id="timer"></div>
     <div id="resultado"></div>
     <div id="acertos"></div>
-    <div id="mode-buttons">
-      <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" class="mode-btn" alt="Modo 1" />
-      <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" class="mode-btn" alt="Modo 2" />
-      <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" class="mode-btn" alt="Modo 3" />
-      <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" class="mode-btn" alt="Modo 4" />
-      <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" class="mode-btn" alt="Modo 5" />
-      <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" class="mode-btn" alt="Modo 6" />
-    </div>
+  <div id="mode-buttons">
+    <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" class="mode-btn" alt="Modo 1" />
+    <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" class="mode-btn" alt="Modo 2" />
+    <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" class="mode-btn" alt="Modo 3" />
+    <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" class="mode-btn" alt="Modo 4" />
+    <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" class="mode-btn" alt="Modo 5" />
+    <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" class="mode-btn" alt="Modo 6" />
   </div>
+</div>
 
   <div id="intro-overlay" style="display:none">
     <img id="intro-image" src="selos%20modos%20de%20jogo/modo1.png" alt="Modo 1">

--- a/js/main.js
+++ b/js/main.js
@@ -89,35 +89,34 @@ let allowInput = true;
 
 if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
   const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-  if (!isMobile) {
-    reconhecimento = new SpeechRecognition();
-    reconhecimento.lang = 'en-US';
-    reconhecimento.continuous = true;
-    reconhecimento.interimResults = false;
+  reconhecimento = new SpeechRecognition();
+  reconhecimento.lang = 'en-US';
+  reconhecimento.continuous = true;
+  reconhecimento.interimResults = false;
 
-    reconhecimento.onstart = () => {
-      reconhecimentoRodando = true;
-    };
+  reconhecimento.onstart = () => {
+    reconhecimentoRodando = true;
+  };
 
-    reconhecimento.onresult = (event) => {
-      const transcript = event.results[event.results.length - 1][0].transcript.trim();
-      const normCmd = transcript.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-      if (ilifeActive) {
-        if (normCmd.includes('play')) {
-          ilifeActive = false;
-          localStorage.setItem('ilifeDone', 'true');
-          const screen = document.getElementById('ilife-screen');
-          const menu = document.getElementById('menu');
-          if (screen) screen.style.display = 'none';
-          if (menu) menu.style.display = 'flex';
-          if (!tutorialDone) {
-            startTutorial();
-          }
+  reconhecimento.onresult = (event) => {
+    const transcript = event.results[event.results.length - 1][0].transcript.trim();
+    const normCmd = transcript.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    if (ilifeActive) {
+      if (normCmd.includes('play')) {
+        ilifeActive = false;
+        localStorage.setItem('ilifeDone', 'true');
+        const screen = document.getElementById('ilife-screen');
+        const menu = document.getElementById('menu');
+        if (screen) screen.style.display = 'none';
+        if (menu) menu.style.display = 'flex';
+        if (!tutorialDone) {
+          startTutorial();
         }
-        return;
       }
-      if (awaitingNextLevel) {
-        if (normCmd.includes('level') || normCmd.includes('next') || normCmd.includes('game')) {
+      return;
+    }
+    if (awaitingNextLevel) {
+      if (normCmd.includes('level') || normCmd.includes('next') || normCmd.includes('game')) {
           awaitingNextLevel = false;
           if (nextLevelCallback) {
             const cb = nextLevelCallback;
@@ -172,8 +171,29 @@ if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
       reconhecimentoRodando = false;
       if (reconhecimentoAtivo) reconhecimento.start();
     };
-  }
+
+    const micBtn = document.getElementById('mic-button');
+    if (micBtn) {
+      micBtn.addEventListener('click', () => {
+        if (reconhecimentoRodando) {
+          reconhecimentoAtivo = false;
+          reconhecimento.stop();
+          micBtn.classList.remove('active');
+        } else {
+          reconhecimentoAtivo = true;
+          try { reconhecimento.start(); } catch (e) {}
+          micBtn.classList.add('active');
+        }
+      });
+      if (isMobile) {
+        reconhecimentoAtivo = true;
+        try { reconhecimento.start(); } catch (e) {}
+        micBtn.classList.add('active');
+      }
+    }
 } else {
+  const micBtn = document.getElementById('mic-button');
+  if (micBtn) micBtn.style.display = 'none';
   alert('Reconhecimento de voz não é suportado neste navegador. Use o Chrome.');
 }
 


### PR DESCRIPTION
## Summary
- make menu and mode buttons responsive for mobile layout
- add microphone button and enable speech recognition on mobile
- start microphone automatically on mobile start screen
- ignore node_modules and package-lock via .gitignore

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68979b2f7bcc8325a4a7e17aa4cd4d19