### PR TITLE
Enable microphone on mobile on first screen

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1733,6 +1733,14 @@ async function initGame() {
         goHome();
       });
     }
+    if (isMobile && navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        stream.getTracks().forEach(track => track.stop());
+      } catch (err) {
+        console.error('Erro ao habilitar microfone:', err);
+      }
+    }
     await initGame();
     if (isMobile) {
       const tapLogo = document.getElementById('ilife-logo');


### PR DESCRIPTION
## Summary
- Request microphone access on mobile devices as soon as the first screen loads to ensure voice recognition works immediately.

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897a3ac7328832599ffea8f83b15db7