### PR TITLE
Adjust layout and tutorial start behaviour

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,10 @@ body {
   overflow: hidden;
 }
 
+body.play-page {
+  overflow-y: auto;
+}
+
 body.dark-mode {
   background: #000;
   color: #fff;
@@ -157,9 +161,10 @@ body.dark-mode #clock {
 #menu-modes {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  gap: 20px;
+  gap: 10px;
   width: 100%;
   max-width: 90vw;
+  margin-top: 50px;
 }
 
 #menu-modes img {
@@ -182,7 +187,7 @@ body.dark-mode #clock {
 }
 
 #pt {
-  font-size: clamp(32px, 6vw, 50px);
+  font-size: clamp(38px, 7.2vw, 60px);
   color: #333;
   background: transparent;
   border: none;
@@ -201,7 +206,7 @@ body.dark-mode #clock {
 
 
 #texto-exibicao {
-  font-size: clamp(32px, 6vw, 50px);
+  font-size: clamp(38px, 7.2vw, 60px);
   color: #333;
   font-family: 'Open Sans', sans-serif;
   font-weight: bold;
@@ -371,7 +376,7 @@ body.dark-mode #clock {
 
 #mode-buttons {
   position: fixed;
-  bottom: 135px;
+  bottom: 85px;
   left: 0;
   width: 100%;
   display: flex;
@@ -877,10 +882,9 @@ body.dark-mode #clock {
 
 @media (max-width: 600px) {
   #texto-exibicao {
-    font-size: clamp(28px, 5.25vw, 43.75px);
+    font-size: clamp(34px, 6.3vw, 52.5px);
     width: calc(100% - 40px);
     height: 180px;
-    border: 1px solid #fff;
     margin: 0 20px;
     background: transparent;
     display: flex;
@@ -891,7 +895,7 @@ body.dark-mode #clock {
     box-sizing: border-box;
   }
   #pt {
-    font-size: clamp(28px, 5.25vw, 43.75px);
+    font-size: clamp(34px, 6.3vw, 52.5px);
   }
   #mode-stats {
     flex-direction: column;
@@ -923,6 +927,14 @@ body.dark-mode #clock {
     transform: translateX(-50%);
     width: 81.6px;
     height: 81.6px;
+  }
+}
+
+@media (max-width: 600px) {
+  #top-nav a[href="explore.html"],
+  #top-nav a[href="custom.html"],
+  #top-nav a[href="fun.html"] {
+    display: none;
   }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1767,26 +1767,26 @@ async function initGame() {
       }
     }
     await initGame();
-    if (isMobile) {
-      const tapLogo = document.getElementById('ilife-logo');
-      if (tapLogo) {
-        let tapCount = 0;
-        let tapTimer;
-        tapLogo.addEventListener('touchstart', () => {
-          tapCount++;
-          clearTimeout(tapTimer);
-          tapTimer = setTimeout(() => { tapCount = 0; }, 500);
-          if (tapCount === 3) {
-            const screen = document.getElementById('ilife-screen');
-            const menu = document.getElementById('menu');
-            if (screen) screen.style.display = 'none';
-            if (menu) menu.style.display = 'flex';
-            ilifeActive = false;
-            localStorage.setItem('ilifeDone', 'true');
-            startTutorial();
-          }
-        });
-      }
+    const tapArea = document.getElementById('ilife-screen');
+    if (tapArea) {
+      let tapCount = 0;
+      let tapTimer;
+      const handleTap = () => {
+        tapCount++;
+        clearTimeout(tapTimer);
+        tapTimer = setTimeout(() => { tapCount = 0; }, 500);
+        if (tapCount === 3) {
+          const screen = document.getElementById('ilife-screen');
+          const menu = document.getElementById('menu');
+          if (screen) screen.style.display = 'none';
+          if (menu) menu.style.display = 'flex';
+          ilifeActive = false;
+          localStorage.setItem('ilifeDone', 'true');
+          startTutorial();
+        }
+      };
+      tapArea.addEventListener('touchstart', handleTap);
+      tapArea.addEventListener('mousedown', handleTap);
     }
     window.addEventListener('beforeunload', () => {
       recordModeTime(selectedMode);

--- a/play.html
+++ b/play.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="dark-mode">
+<body class="dark-mode play-page">
   <nav id="top-nav">
     <a href="index.html">home</a>
     <a href="fun.html">fun</a>


### PR DESCRIPTION
## Summary
- Reduce spacing for mode icons and shift them down for clarity
- Remove white border and enlarge display text on mobile
- Allow scroll on play page and hide Explore, Custom, Fun links on mobile
- Trigger tutorial after triple tap on the intro screen

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6897c77da530832592ce4193140947dd