### PR TITLE
Add level header, secret unlock, and mobile gestures

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -68,6 +68,10 @@ body.dark-mode #timer {
   caret-color: #fff;
 }
 
+body.dark-mode #texto-exibicao {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
 #top-nav {
   display: flex;
   justify-content: center;
@@ -132,9 +136,9 @@ body.dark-mode #intro-overlay {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 40px;
+  justify-content: flex-start;
   height: 100vh;
+  padding-top: 20px;
 }
 
 #clock {
@@ -145,9 +149,17 @@ body.dark-mode #intro-overlay {
   text-align: center;
 }
 
+#menu-level {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  text-align: center;
+}
+
 #menu-logo {
-  width: 100px;
-  height: auto;
+  width: 150px;
+  height: 150px;
+  margin-top: 30px;
 }
 
 body.dark-mode #menu-logo {
@@ -216,6 +228,7 @@ body.dark-mode #clock {
   align-items: center;
   justify-content: center;
   white-space: normal;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 #score {
@@ -393,6 +406,7 @@ body.dark-mode #clock {
   #mode-icon {
     width: 150px;
     height: 150px;
+    margin-top: 15px;
   }
 
   #clock {
@@ -865,6 +879,7 @@ body.dark-mode #clock {
   #mode-icon {
     width: 150px;
     height: 150px;
+    margin-top: 15px;
   }
   #barra-progresso {
     margin-top: 0;

--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
     </div>
   <img id="tutorial-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" style="display:none" />
   <div id="menu" style="display:none">
+    <div id="menu-level"></div>
+    <img id="menu-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">
     <div id="menu-modes">
       <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
       <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">


### PR DESCRIPTION
## Summary
- Show current level and logo above mode selection menu
- Start microphone automatically when a phrase loads and add secret mode-unlock sequence
- Add mobile gestures for theme switch, reporting, and microphone activation with updated UI styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897d98af12483258b4a722739a297ac