### PR TITLE
Add hidden mode selector and mobile stats bars

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -604,6 +604,38 @@ body.dark-mode #clock {
   color: lime;
 }
 
+.play-stat-bar {
+  width: 270px;
+  margin: 20px auto;
+  text-align: center;
+  font-family: 'Open Sans', sans-serif;
+}
+
+.play-bar-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 5px;
+}
+
+.play-bar-bg {
+  width: 270px;
+  height: 20px;
+  background: #333;
+  margin: 0 auto;
+}
+
+.play-bar-fill {
+  height: 100%;
+  width: 0;
+  background: #00cc66;
+  transition: width 1s;
+}
+
+.play-bar-value {
+  margin-top: 5px;
+  font-weight: 700;
+}
+
 #fun-content {
   margin-top:50px;
   display:flex;


### PR DESCRIPTION
## Summary
- Introduce secret mode sequence to unlock 128-mode dropdown via level text
- Double reward points to 1000 and add forgiving word check in mode 1
- Replace play menu circles with labeled horizontal bars using unified time metric

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897ffb961948325bd2fd92e842efb98