### PR TITLE
Refine play layout and game mode rules

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -395,11 +395,27 @@ body.dark-mode #clock {
   transition: opacity 0.2s linear;
 }
 
+.play-page #mode-buttons {
+  left: 50%;
+  bottom: 100px;
+  width: auto;
+  transform: translateX(-50%);
+  display: grid;
+  grid-template-columns: repeat(3, 75px);
+  grid-template-rows: repeat(2, 75px);
+  gap: 20px;
+}
+
+.play-page #mode-buttons img {
+  width: 75px;
+  height: 75px;
+}
+
 #play-content {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
-  gap: 40px;
+  gap: 20px;
 }
 
 @media (max-width: 600px) {

--- a/index.html
+++ b/index.html
@@ -44,9 +44,7 @@
     <!-- conteúdo visual aqui -->
     <div id="score"></div>
     <div id="mode-stats">
-      <div id="general-score-circle"></div>
       <img id="mode-icon" alt="Mode Icon" style="display:none" />
-      <div id="general-speed-circle"></div>
     </div>
     <div id="texto-exibicao"></div>
     <div id="barra-progresso">

--- a/js/main.js
+++ b/js/main.js
@@ -471,7 +471,6 @@ function saveModeStats() {
   if (typeof saveUserPerformance === 'function') {
     saveUserPerformance(modeStats);
   }
-  updateGeneralCircles();
 }
 
 function saveTotals() {
@@ -809,59 +808,6 @@ function calcularCor(pontos) {
   return colorStops[colorStops.length - 1][1];
 }
 
-function colorFromPercent(perc) {
-  const max = colorStops[colorStops.length - 1][0];
-  return calcularCor((perc / 100) * max);
-}
-
-function createStatCircle(perc, label, iconSrc, extraText) {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'stat-circle';
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.setAttribute('viewBox', '0 0 120 120');
-  const radius = 38;
-  const circumference = 2 * Math.PI * radius;
-  const bg = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-  bg.setAttribute('class', 'circle-bg');
-  bg.setAttribute('cx', '60');
-  bg.setAttribute('cy', '60');
-  bg.setAttribute('r', radius);
-  svg.appendChild(bg);
-  const prog = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-  prog.setAttribute('class', 'circle-progress');
-  prog.setAttribute('cx', '60');
-  prog.setAttribute('cy', '60');
-  prog.setAttribute('r', radius);
-  prog.setAttribute('stroke-dasharray', circumference);
-  const clamped = Math.max(0, Math.min(perc, 100));
-  prog.setAttribute('stroke-dashoffset', circumference);
-  prog.style.stroke = colorFromPercent(perc);
-  svg.appendChild(prog);
-  wrapper.appendChild(svg);
-  const icon = document.createElement('img');
-  icon.className = 'circle-icon';
-  icon.src = iconSrc;
-  icon.alt = label;
-  wrapper.appendChild(icon);
-  setTimeout(() => {
-    prog.setAttribute('stroke-dashoffset', circumference * (1 - clamped / 100));
-  }, 50);
-  const value = document.createElement('div');
-  value.className = 'circle-value';
-  value.textContent = `${Math.round(perc)}%`;
-  wrapper.appendChild(value);
-  const labelEl = document.createElement('div');
-  labelEl.className = 'circle-label';
-  labelEl.textContent = label;
-  wrapper.appendChild(labelEl);
-  if (extraText) {
-    const extra = document.createElement('div');
-    extra.className = 'circle-extra';
-    extra.textContent = extraText;
-    wrapper.appendChild(extra);
-  }
-  return wrapper;
-}
 
 function calcModeStats(mode) {
   const stats = modeStats[mode] || {};
@@ -879,46 +825,6 @@ function calcModeStats(mode) {
   return { accPerc, timePerc, avg, notReportPerc };
 }
 
-function calcGeneralStats() {
-  const modes = [2, 3, 4, 5, 6];
-  let totalPhrases = 0, totalCorrect = 0, totalTime = 0, totalReport = 0;
-  let timePercSum = 0, timePercCount = 0;
-  modes.forEach(m => {
-    const s = modeStats[m] || {};
-    totalPhrases += s.totalPhrases || 0;
-    totalCorrect += s.correct || 0;
-    totalTime += s.totalTime || 0;
-    totalReport += s.report || 0;
-    const tp = calcModeStats(m).timePerc;
-    if (tp >= 1) {
-      timePercSum += tp;
-      timePercCount++;
-    }
-  });
-  const accPerc = totalPhrases ? (totalCorrect / totalPhrases * 100) : 0;
-  const avg = totalPhrases ? (totalTime / totalPhrases / 1000) : 0;
-  const timePerc = timePercCount ? (timePercSum / timePercCount) : 0;
-  const notReportPerc = totalPhrases ? (100 - (totalReport / totalPhrases * 100)) : 100;
-  return { accPerc, timePerc, avg, notReportPerc };
-}
-
-function updateGeneralCircles() {
-  const { accPerc, timePerc } = calcGeneralStats();
-  const scoreWrapper = document.getElementById('general-score-circle');
-  const speedWrapper = document.getElementById('general-speed-circle');
-  if (scoreWrapper) {
-    scoreWrapper.innerHTML = '';
-    scoreWrapper.appendChild(
-      createStatCircle(accPerc, 'Pontuação Geral', 'selos%20modos%20de%20jogo/precisao.png')
-    );
-  }
-  if (speedWrapper) {
-    speedWrapper.innerHTML = '';
-    speedWrapper.appendChild(
-      createStatCircle(timePerc, 'Velocidade Geral', 'selos%20modos%20de%20jogo/velocidade.png')
-    );
-  }
-}
 
 let introProgressInterval = null;
 
@@ -1151,16 +1057,15 @@ function beginGame() {
       icon.style.display = 'block';
       icon.onclick = () => { if (paused) resumeGame(); };
     }
-    updateGeneralCircles();
     const texto = document.getElementById('texto-exibicao');
     if (texto) texto.style.opacity = '1';
     updateLevelIcon();
     updateModeIcons();
     switch (selectedMode) {
       case 1:
-        mostrarTexto = 'pt';
+        mostrarTexto = 'en';
         voz = 'en';
-        esperadoLang = 'pt';
+        esperadoLang = 'en';
         break;
     case 2:
       mostrarTexto = 'pt';
@@ -1178,9 +1083,9 @@ function beginGame() {
       esperadoLang = 'en';
       break;
     case 5:
-      mostrarTexto = 'none';
-      voz = 'en';
-      esperadoLang = 'pt';
+      mostrarTexto = 'pt';
+      voz = null;
+      esperadoLang = 'en';
       break;
     case 6:
       mostrarTexto = 'pt';


### PR DESCRIPTION
## Summary
- remove score and speed circles from game UI
- stack play stats vertically and show mode buttons in a centered grid
- adjust mode 1 & 5 language behavior and drop synthetic voice in mode 5

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898a21d8a4c83258ba11d7308096443