### PR TITLE
Refine stats display and rename speed metric to report

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -622,9 +622,13 @@ body.dark-mode #clock {
 
 .play-stat-bar {
   width: 270px;
-  margin: 20px auto;
+  margin: 10px auto;
   text-align: center;
   font-family: 'Open Sans', sans-serif;
+}
+
+#play-content .play-stat-bar:first-child {
+  margin-top: 30px;
 }
 
 .play-bar-title {
@@ -645,11 +649,6 @@ body.dark-mode #clock {
   width: 0;
   background: #00cc66;
   transition: width 1s;
-}
-
-.play-bar-value {
-  margin-top: 5px;
-  font-weight: 700;
 }
 
 #fun-content {

--- a/js/play.js
+++ b/js/play.js
@@ -53,22 +53,18 @@ function createStatBar(perc, label) {
     wrapper.className = 'play-stat-bar';
     const title = document.createElement('div');
     title.className = 'play-bar-title';
-  title.textContent = label;
-  wrapper.appendChild(title);
+    title.textContent = `${label} ${Math.round(perc)}%`;
+    wrapper.appendChild(title);
     const bar = document.createElement('div');
     bar.className = 'play-bar-bg';
     const fill = document.createElement('div');
     fill.className = 'play-bar-fill';
-  fill.style.backgroundColor = colorFromPercent(perc);
-  bar.appendChild(fill);
-  wrapper.appendChild(bar);
-    const value = document.createElement('div');
-    value.className = 'play-bar-value';
-  value.textContent = `${Math.round(perc)}%`;
-  wrapper.appendChild(value);
-  const clamped = Math.max(0, Math.min(perc, 100));
-  setTimeout(() => { fill.style.width = clamped + '%'; }, 50);
-  return wrapper;
+    fill.style.backgroundColor = colorFromPercent(perc);
+    bar.appendChild(fill);
+    wrapper.appendChild(bar);
+    const clamped = Math.max(0, Math.min(perc, 100));
+    setTimeout(() => { fill.style.width = clamped + '%'; }, 50);
+    return wrapper;
 }
 const TIME_POINT_REFS = {
   1: 125,
@@ -108,8 +104,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const ref = TIME_POINT_REFS[mode] || 100;
     let timePerc = total ? ((timePts / total) / ref) * 100 : 0;
     timePerc *= SPEED_SCALE;
-    const speedPerc = total ? (100 - (report / total * 100)) : 100;
-    return { accPerc, timePerc, speedPerc };
+    const reportPerc = total ? (report / total * 100) : 0;
+    return { accPerc, timePerc, reportPerc };
   }
 
   function calcGeneralStats() {
@@ -128,8 +124,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const accPerc = totalPhrases ? (totalCorrect / totalPhrases * 100) : 0;
     let timePerc = totalRef ? (totalTimePts / totalRef) * 100 : 0;
     timePerc *= SPEED_SCALE;
-    const speedPerc = totalPhrases ? (100 - (totalReport / totalPhrases * 100)) : 100;
-    return { accPerc, timePerc, speedPerc };
+    const reportPerc = totalPhrases ? (totalReport / totalPhrases * 100) : 0;
+    return { accPerc, timePerc, reportPerc };
   }
 
   function startVersus(name, mode) {
@@ -181,15 +177,15 @@ document.addEventListener('DOMContentLoaded', () => {
     setTimeout(() => {
       container.innerHTML = '';
       if (mode === 1) {
-        const { accPerc, timePerc, speedPerc } = calcGeneralStats();
+        const { accPerc, timePerc, reportPerc } = calcGeneralStats();
         container.appendChild(createStatBar(accPerc, 'Precisão'));
         container.appendChild(createStatBar(timePerc, 'Tempo'));
-        container.appendChild(createStatBar(speedPerc, 'Velocidade'));
+        container.appendChild(createStatBar(reportPerc, 'Report'));
       } else {
-        const { accPerc, timePerc, speedPerc } = calcModeStats(mode);
+        const { accPerc, timePerc, reportPerc } = calcModeStats(mode);
         container.appendChild(createStatBar(accPerc, 'Precisão'));
         container.appendChild(createStatBar(timePerc, 'Tempo'));
-        container.appendChild(createStatBar(speedPerc, 'Velocidade'));
+        container.appendChild(createStatBar(reportPerc, 'Report'));
       }
       container.style.opacity = 1;
     }, 150);

--- a/play.html
+++ b/play.html
@@ -16,7 +16,7 @@
     <a href="versus.html">versus</a>
     <a href="explore.html">explore</a>
   </nav>
-  <div id="play-content" style="text-align:center;margin-top:50px;"></div>
+  <div id="play-content" style="text-align:center;margin-top:0;"></div>
   <div id="versus-stats" style="display:none;text-align:center;margin-top:50px;">
     <h2 id="vs-title"></h2>
     <div id="round"></div>


### PR DESCRIPTION
## Summary
- Show percentage next to stat title and drop standalone value element
- Rename speed metric to report and recalc using report usage
- Tighten stat bar spacing and ensure first bar sits 30px below header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898acfdb8708325bb9fab8cc3d054dc