### PR TITLE
Add mobile black theme and white text for blue mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -54,8 +54,22 @@ body.versus-blue #top-nav a {
   color: #fff;
 }
 
+body.versus-black {
+  background: linear-gradient(to bottom, #555, #000);
+  color: #fff;
+}
+
+body.versus-black #top-nav {
+  background: linear-gradient(90deg, #333, #000);
+}
+
+body.versus-black #top-nav a {
+  color: #fff;
+}
+
 body.versus-blue,
-body.versus-white {
+body.versus-white,
+body.versus-black {
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -89,6 +103,18 @@ body.dark-mode #top-nav {
   background: linear-gradient(90deg, #006666, #008080);
 }
 
+body.dark-mode.versus-blue #top-nav {
+  background: linear-gradient(90deg, #40e0d0, #0066cc);
+}
+
+body.dark-mode.versus-white #top-nav {
+  background: linear-gradient(90deg, #e0e0e0, #f5f5f5);
+}
+
+body.dark-mode.versus-black #top-nav {
+  background: linear-gradient(90deg, #333, #000);
+}
+
 #top-nav a {
   color: #fff;
   text-decoration: none;
@@ -98,6 +124,10 @@ body.dark-mode #top-nav {
 
 body.dark-mode #top-nav a {
   color: #fff;
+}
+
+body.dark-mode.versus-white #top-nav a {
+  color: #555;
 }
 
 body.gradient-mode #top-nav {
@@ -811,6 +841,15 @@ body.dark-mode #clock {
   text-align: center;
   font-size: 35px;
   min-height: 40px;
+}
+
+body.versus-blue #versus-phrase,
+body.versus-black #versus-phrase {
+  color: #fff;
+}
+
+body.versus-white #versus-phrase {
+  color: #555;
 }
 
 .player-name {

--- a/js/main.js
+++ b/js/main.js
@@ -381,15 +381,14 @@ function toggleDarkMode() {
 
 applyColorMode();
 
+const themes = ['versus-blue', 'versus-white', 'versus-black'];
+let themeIndex = themes.findIndex(t => document.body.classList.contains(t));
+
 function toggleTheme() {
   const body = document.body;
-  if (body.classList.contains('versus-blue')) {
-    body.classList.remove('versus-blue');
-    body.classList.add('versus-white');
-  } else {
-    body.classList.remove('versus-white');
-    body.classList.add('versus-blue');
-  }
+  body.classList.remove(...themes);
+  themeIndex = (themeIndex + 1) % themes.length;
+  body.classList.add(themes[themeIndex]);
 }
 
 const reportClickHandler = () => {

--- a/js/versus.js
+++ b/js/versus.js
@@ -145,13 +145,17 @@ document.addEventListener('DOMContentLoaded', () => {
   let userImg = null;
   let userNameEl = null;
 
+  const themes = ['versus-blue', 'versus-white', 'versus-black'];
+  let themeIndex = themes.findIndex(t => document.body.classList.contains(t));
+
   function applyTheme() {
     fraseEl.style.color = document.body.classList.contains('versus-white') ? '#555' : '#fff';
   }
 
   function toggleTheme() {
-    document.body.classList.toggle('versus-white');
-    document.body.classList.toggle('versus-blue');
+    themeIndex = (themeIndex + 1) % themes.length;
+    document.body.classList.remove(...themes);
+    document.body.classList.add(themes[themeIndex]);
     applyTheme();
   }
 


### PR DESCRIPTION
## Summary
- Ensure versus blue mode uses white font for phrase text
- Add new versus-black theme with dark gray gradient and white text
- Cycle mobile themes through blue, white, and black when swiping

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898c070525883259ec636b032198afe