### PR TITLE
Set theme-aware text colors in game UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -94,6 +94,18 @@ body.dark-mode #texto-exibicao {
   border: 1px solid rgba(255, 255, 255, 0);
 }
 
+body.versus-blue #pt,
+body.versus-blue #texto-exibicao {
+  color: #fff;
+  caret-color: #fff;
+}
+
+body.versus-black #pt,
+body.versus-black #texto-exibicao {
+  color: #ccc;
+  caret-color: #ccc;
+}
+
 #top-nav {
   display: flex;
   justify-content: center;

--- a/js/main.js
+++ b/js/main.js
@@ -1243,7 +1243,7 @@ function flashSuccess(callback) {
   texto.style.color = color;
   setTimeout(() => {
     texto.style.transition = 'color 500ms linear';
-    texto.style.color = '#333';
+    texto.style.color = '';
     setTimeout(() => {
       document.getElementById('resultado').textContent = '';
       callback();
@@ -1259,7 +1259,7 @@ function flashError(expected, callback) {
   texto.style.color = 'red';
   setTimeout(() => {
     texto.style.transition = 'color 500ms linear';
-    texto.style.color = '#333';
+    texto.style.color = '';
     setTimeout(() => {
       texto.textContent = previous;
       document.getElementById('resultado').textContent = '';


### PR DESCRIPTION
## Summary
- Customize text box and display font colors per game theme
- Let flash effects reset to theme colors instead of fixed gray

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898ce885b9083259edec7843067223a