### PR TITLE
Reduce desktop menu icon size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -230,15 +230,22 @@ body.dark-mode #clock {
   width: 100%;
   max-width: 90vw;
   margin-top: 50px;
+  justify-items: center;
 }
 
 #menu-modes img {
-  width: 100%;
+  width: 50%;
   height: auto;
   object-fit: contain;
   cursor: pointer;
   opacity: 0.3;
   transition: opacity 0.2s linear;
+}
+
+@media (max-width: 600px) {
+  #menu-modes img {
+    width: 100%;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- Halve main menu game mode icon size on desktop and keep them centered
- Preserve full-size icons on small screens via media query

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689905aefd348325a811b1eac28dadd2