### PR TITLE
Add support for phrases with multiple English translations

### DIFF
--- a/data/pastas.json
+++ b/data/pastas.json
@@ -53,7 +53,7 @@ Você ajuda#You help
 Ele ajuda#He helps
 Nós ajudamos#We help
 Eles ajudam#They help
-Eu amo#I love
+Eu amo#I love#I adore
 Você ama#You love
 Ele ama#He loves
 Nós amamos#We love
@@ -63,7 +63,7 @@ Você vê#You see
 Ele vê#He sees
 Nós vemos#We see
 Eles veem#They see
-Eu digo#I say
+Eu digo#I say#I tell
 Você diz#You say
 Ele diz#He says
 Nós dizemos#We say

--- a/data/pastasversus.json
+++ b/data/pastasversus.json
@@ -1,12 +1,12 @@
 {
   "frases": [
-  "cachorro#dog",
+  "cachorro#dog#hound",
   "gato#cat",
   "livro#book",
   "carro#car",
   "casa#house",
   "porta#door",
-  "telefone#phone",
+  "telefone#phone#telephone",
   "maçã#apple",
   "mesa#table",
   "água#water",


### PR DESCRIPTION
## Summary
- Allow data files to specify several English translations per Portuguese phrase
- Show and speak one English translation and accept any as correct
- Update example data to demonstrate new multi-translation format

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a601de5f08325bb910afbda508495