### PR TITLE
Support homophone variations via external data file

### DIFF
--- a/data/homophones.txt
+++ b/data/homophones.txt
@@ -1,0 +1,3 @@
+here@hear
+to@too@two
+knight@night

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,21 @@ async function carregarFrasesCorretas() {
   } catch (e) {
     frasesCorretas = {};
   }
+
+  try {
+    const resp = await fetch('data/homophones.txt');
+    const text = await resp.text();
+    text.split(/\n+/).forEach(l => {
+      const parts = l.trim().toLowerCase().split('@').filter(Boolean);
+      if (parts.length > 1) {
+        const [correta, ...variantes] = parts;
+        if (!frasesCorretas[correta]) frasesCorretas[correta] = [];
+        frasesCorretas[correta].push(...variantes);
+      }
+    });
+  } catch (e) {
+    // ignore missing file
+  }
 }
 
 function aplicarFrasesCorretas(texto) {


### PR DESCRIPTION
## Summary
- load `data/homophones.txt` to treat listed word variants as equivalent
- normalize text by replacing homophone variants with their canonical form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689aad8488e48325a939426c9876f5b5