### PR TITLE
Support homophone variations via external data file

### DIFF
--- a/data/homophones.json
+++ b/data/homophones.json
@@ -1,0 +1,5 @@
+[
+  ["here", "hear"],
+  ["to", "too", "two"],
+  ["knight", "night"]
+]

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,20 @@ async function carregarFrasesCorretas() {
   } catch (e) {
     frasesCorretas = {};
   }
+
+  try {
+    const resp = await fetch('data/homophones.json');
+    const groups = await resp.json();
+    groups.forEach(group => {
+      if (Array.isArray(group) && group.length > 1) {
+        const [correta, ...variantes] = group.map(w => w.trim().toLowerCase());
+        if (!frasesCorretas[correta]) frasesCorretas[correta] = [];
+        frasesCorretas[correta].push(...variantes);
+      }
+    });
+  } catch (e) {
+    // ignore missing file
+  }
 }
 
 function aplicarFrasesCorretas(texto) {


### PR DESCRIPTION
## Summary
- replace `homophones.txt` with `homophones.json` listing homophone groups like `here/hear`
- load homophone groups from JSON and merge into phrase normalization

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689aad8488e48325a939426c9876f5b5