### PR TITLE
Add complementary game modes and tweak phrase display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,12 +224,14 @@ body.dark-mode #clock {
 }
 
 #menu-modes {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
   width: 100%;
   max-width: 90vw;
   margin-top: 50px;
+}
+#menu-modes .mode-group {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
   justify-items: center;
 }
 
@@ -442,8 +444,11 @@ body.dark-mode #clock {
   width: 100%;
   display: flex;
   justify-content: center;
-  gap: 10px;
   z-index: 999;
+}
+#mode-buttons .mode-group {
+  display: flex;
+  gap: 10px;
 }
 
 #mode-buttons img {

--- a/index.html
+++ b/index.html
@@ -30,12 +30,22 @@
     <div id="menu-level"></div>
     <img id="menu-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">
     <div id="menu-modes">
-      <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
-      <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">
-      <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" alt="Modo 3">
-      <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" alt="Modo 4">
-      <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" alt="Modo 5">
-      <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" alt="Modo 6">
+      <div class="mode-group" id="mode-group-1">
+        <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
+        <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">
+        <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" alt="Modo 3">
+        <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" alt="Modo 4">
+        <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" alt="Modo 5">
+        <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" alt="Modo 6">
+      </div>
+      <div class="mode-group" id="mode-group-2" style="display:none">
+        <img src="selos%20modos%20de%20jogo/modo7.png" data-mode="7" alt="Modo 7">
+        <img src="selos%20modos%20de%20jogo/modo8.png" data-mode="8" alt="Modo 8">
+        <img src="selos%20modos%20de%20jogo/modo9.png" data-mode="9" alt="Modo 9">
+        <img src="selos%20modos%20de%20jogo/modo10.png" data-mode="10" alt="Modo 10">
+        <img src="selos%20modos%20de%20jogo/modo11.png" data-mode="11" alt="Modo 11">
+        <img src="selos%20modos%20de%20jogo/modo12.png" data-mode="12" alt="Modo 12">
+      </div>
     </div>
   </div>
 
@@ -58,12 +68,22 @@
     <div id="resultado"></div>
     <div id="acertos"></div>
   <div id="mode-buttons">
-    <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" class="mode-btn" alt="Modo 1" />
-    <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" class="mode-btn" alt="Modo 2" />
-    <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" class="mode-btn" alt="Modo 3" />
-    <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" class="mode-btn" alt="Modo 4" />
-    <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" class="mode-btn" alt="Modo 5" />
-    <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" class="mode-btn" alt="Modo 6" />
+    <div class="mode-group" id="mode-buttons-1">
+      <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" class="mode-btn" alt="Modo 1" />
+      <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" class="mode-btn" alt="Modo 2" />
+      <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" class="mode-btn" alt="Modo 3" />
+      <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" class="mode-btn" alt="Modo 4" />
+      <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" class="mode-btn" alt="Modo 5" />
+      <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" class="mode-btn" alt="Modo 6" />
+    </div>
+    <div class="mode-group" id="mode-buttons-2" style="display:none">
+      <img src="selos%20modos%20de%20jogo/modo7.png" data-mode="7" class="mode-btn" alt="Modo 7" />
+      <img src="selos%20modos%20de%20jogo/modo8.png" data-mode="8" class="mode-btn" alt="Modo 8" />
+      <img src="selos%20modos%20de%20jogo/modo9.png" data-mode="9" class="mode-btn" alt="Modo 9" />
+      <img src="selos%20modos%20de%20jogo/modo10.png" data-mode="10" class="mode-btn" alt="Modo 10" />
+      <img src="selos%20modos%20de%20jogo/modo11.png" data-mode="11" class="mode-btn" alt="Modo 11" />
+      <img src="selos%20modos%20de%20jogo/modo12.png" data-mode="12" class="mode-btn" alt="Modo 12" />
+    </div>
   </div>
 </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -350,6 +350,9 @@ function getTimeMetrics(len, mode) {
 }
 let completedModes = JSON.parse(localStorage.getItem('completedModes') || '{}');
 let unlockedModes = JSON.parse(localStorage.getItem('unlockedModes') || '{}');
+for (let m = 7; m <= 12; m++) {
+  if (unlockedModes[m] === undefined) unlockedModes[m] = true;
+}
 let modeIntroShown = JSON.parse(localStorage.getItem('modeIntroShown') || '{}');
 let points = parseInt(localStorage.getItem('points') || INITIAL_POINTS, 10);
 let premioBase = parseInt(localStorage.getItem("premioBase"), 10) || 1000;
@@ -464,7 +467,13 @@ const modeImages = {
   3: 'selos%20modos%20de%20jogo/modo3.png',
   4: 'selos%20modos%20de%20jogo/modo4.png',
   5: 'selos%20modos%20de%20jogo/modo5.png',
-  6: 'selos%20modos%20de%20jogo/modo6.png'
+  6: 'selos%20modos%20de%20jogo/modo6.png',
+  7: 'selos%20modos%20de%20jogo/modo7.png',
+  8: 'selos%20modos%20de%20jogo/modo8.png',
+  9: 'selos%20modos%20de%20jogo/modo9.png',
+  10: 'selos%20modos%20de%20jogo/modo10.png',
+  11: 'selos%20modos%20de%20jogo/modo11.png',
+  12: 'selos%20modos%20de%20jogo/modo12.png'
 };
 
 const modeTransitions = {
@@ -711,6 +720,23 @@ function getHighestUnlockedMode() {
 
 function checkForMenuLevelUp() {
   // Level advancement is triggered only after finishing mode 6
+}
+
+let modePage = 1;
+function setModePage(page) {
+  modePage = page;
+  const g1 = document.getElementById('mode-group-1');
+  const g2 = document.getElementById('mode-group-2');
+  const b1 = document.getElementById('mode-buttons-1');
+  const b2 = document.getElementById('mode-buttons-2');
+  if (g1 && g2) {
+    g1.style.display = page === 1 ? 'grid' : 'none';
+    g2.style.display = page === 2 ? 'grid' : 'none';
+  }
+  if (b1 && b2) {
+    b1.style.display = page === 1 ? 'flex' : 'none';
+    b2.style.display = page === 2 ? 'flex' : 'none';
+  }
 }
 
 function performMenuLevelUp() {
@@ -1241,7 +1267,7 @@ function mostrarFrase() {
   if (inputTimeout) clearTimeout(inputTimeout);
   if (fraseIndex >= frasesArr.length) fraseIndex = 0;
   const [pt, ens] = frasesArr[fraseIndex];
-  const en = ens[Math.floor(Math.random() * ens.length)];
+  const en = ens[0];
   const texto = document.getElementById("texto-exibicao");
   if (mostrarTexto === 'pt') texto.textContent = pt;
   else if (mostrarTexto === 'en') texto.textContent = en;
@@ -1803,6 +1829,10 @@ async function initGame() {
       }
     }
     await initGame();
+    document.addEventListener('keydown', e => {
+      if (e.key === 'ArrowRight') setModePage(2);
+      if (e.key === 'ArrowLeft') setModePage(1);
+    });
     if (isMobile) {
       let startX = 0, startY = 0;
       document.addEventListener('touchstart', e => {
@@ -1815,7 +1845,12 @@ async function initGame() {
         const dx = t.screenX - startX;
         const dy = t.screenY - startY;
         if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
-          if (dx > 0) {
+          const menuEl = document.getElementById('menu');
+          const menuVisible = menuEl && menuEl.style.display !== 'none';
+          if (menuVisible) {
+            if (dx < 0) setModePage(2);
+            else setModePage(1);
+          } else if (dx > 0) {
             toggleTheme();
           } else {
             reportLastError();


### PR DESCRIPTION
## Summary
- Only display primary Portuguese and English phrases while keeping additional translations for validation
- Introduce modes 7–12 with corresponding icons and navigation via swipe or arrow keys
- Adjust styling to support paged mode groups

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689ac83a5cb48325985f6f4756733e62