### PR TITLE
Show presents images for mode 7

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,6 +18,17 @@ app.get('/photos/list', (req, res) => {
   });
 });
 
+app.get('/presents/list', (req, res) => {
+  const dir = path.join(__dirname, 'presents');
+  fs.readdir(dir, (err, files) => {
+    if (err) {
+      return res.status(500).json({ error: 'Unable to list presents' });
+    }
+    const images = files.filter(f => /\.(png|jpe?g|gif)$/i.test(f));
+    res.json(images);
+  });
+});
+
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add endpoint to list images in the new `presents` folder
- load present images and display matching image for phrases in mode 7

## Testing
- `node -e "require('./server.js'); setTimeout(()=>process.exit(0), 1000)"`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689aeeb0d43883258b94b21583c88d27