### PR TITLE
Show presents images in mode 8

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1023,3 +1023,15 @@ body.versus-white #versus-phrase {
   }
 }
 
+#mode8-presents {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+
+#mode8-presents img {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+}

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
       <select id="song-select"></select>
       <audio id="song-audio"></audio>
     </div>
+    <div id="mode8-presents" style="display:none"></div>
     <div id="barra-progresso">
       <div id="barra-preenchida"></div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -124,8 +124,10 @@ async function carregarPresentes() {
 function setupMode8() {
   const controls = document.getElementById('mode8-controls');
   const selector = document.getElementById('song-select');
+  const presents = document.getElementById('mode8-presents');
   songAudio = document.getElementById('song-audio');
   if (controls) controls.style.display = 'flex';
+  if (presents) presents.style.display = 'flex';
   if (!selector || !songAudio) return;
   fetch('/songs/list')
     .then(r => r.json())
@@ -138,6 +140,19 @@ function setupMode8() {
         selector.appendChild(opt);
       });
     });
+  if (presents) {
+    fetch('/presents/list')
+      .then(r => r.json())
+      .then(files => {
+        presents.innerHTML = '';
+        files.forEach(f => {
+          const img = document.createElement('img');
+          img.src = `presents/${encodeURIComponent(f)}`;
+          img.alt = f.replace(/\.[^.]+$/, '');
+          presents.appendChild(img);
+        });
+      });
+  }
   selector.onchange = () => {
     if (!selector.value) return;
     songAudio.src = selector.value;
@@ -1252,6 +1267,8 @@ function beginGame() {
     updateModeIcons();
     const m8 = document.getElementById('mode8-controls');
     if (m8) m8.style.display = selectedMode === 8 ? 'flex' : 'none';
+    const m8p = document.getElementById('mode8-presents');
+    if (m8p) m8p.style.display = selectedMode === 8 ? 'flex' : 'none';
     switch (selectedMode) {
       case 1:
         mostrarTexto = 'en';


### PR DESCRIPTION
## Summary
- Add container for presents images and show it in mode 8
- Load images from /presents and render them in a grid
- Style presents grid for organized layout

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b4ffc8cd083258bd3364b78182b26