### PR TITLE
Disable mobile scroll in game modes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -74,8 +74,9 @@ body.versus-black #top-nav a {
 body.versus-blue,
 body.versus-white,
 body.versus-black {
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
+  touch-action: none;
+  overscroll-behavior: none;
 }
 
 


### PR DESCRIPTION
## Summary
- stop vertical scrolling on mobile game modes by locking overflow and touch behavior on body styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f6994b6f0832587b32ea4c4264e9b