### PR TITLE
Refine gameplay interactions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,6 +4,9 @@ body {
   font-family: 'Open Sans', sans-serif;
   --grad-color: #40e0d0;
   overflow: hidden;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 body.stats-page {
@@ -30,6 +33,16 @@ body.gradient-mode {
 body.custom-gradient {
   background: linear-gradient(135deg, #f5f5f5 0%, #ffffff 100%);
   color: #333;
+}
+
+textarea, input {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+img {
+  -webkit-user-drag: none;
+  user-select: none;
 }
 
 body.versus-white {
@@ -997,8 +1010,14 @@ body.versus-white #versus-phrase {
     flex-wrap: wrap;
     row-gap: 10px;
   }
+  #mode-buttons .mode-group {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+  }
   #mode-buttons img {
-    flex: 0 0 24%;
+    flex: none;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Use the central mode icon to repeat sentences and remove double-tap gestures
- Train a fixed set of 12 phrases per level across modes with immediate starts and simplified level progression
- Disable text/image selection and reorganize mobile mode buttons into two rows

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f792764048325b75cc9e35f992e0a